### PR TITLE
添加 DamageRecord；完善了预制技能灵魂绑定；添加更多钩子

### DIFF
--- a/Entity/Skill/Effect.cs
+++ b/Entity/Skill/Effect.cs
@@ -455,7 +455,20 @@ namespace Milimoe.FunGame.Core.Entity
         }
 
         /// <summary>
-        /// 在技能释放前触发
+        /// 在技能释放前触发 [ 技能的特效组 ]
+        /// </summary>
+        /// <param name="caster"></param>
+        /// <param name="targets"></param>
+        /// <param name="grids"></param>
+        /// <param name="mpCost"></param>
+        /// <param name="epCost"></param>
+        public virtual void BeforeSkillCasted(Character caster, List<Character> targets, List<Grid> grids, double mpCost = 0, double epCost = 0)
+        {
+
+        }
+
+        /// <summary>
+        /// 在技能释放前触发 [ 状态栏特效 ]
         /// </summary>
         /// <param name="caster"></param>
         /// <param name="skill"></param>
@@ -466,6 +479,17 @@ namespace Milimoe.FunGame.Core.Entity
         public virtual bool BeforeSkillCasted(Character caster, Skill skill, List<Character> targets, List<Grid> grids, Dictionary<string, object> others)
         {
             return true;
+        }
+
+        /// <summary>
+        /// 在技能释放后触发 [ 技能的特效组 ]
+        /// </summary>
+        /// <param name="caster"></param>
+        /// <param name="targets"></param>
+        /// <param name="grids"></param>
+        public virtual void AfterSkillCasted(Character caster, List<Character> targets, List<Grid> grids)
+        {
+
         }
 
         /// <summary>
@@ -1051,21 +1075,24 @@ namespace Milimoe.FunGame.Core.Entity
         /// <param name="expectedDamage"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public DamageResult DamageToEnemy(Character actor, Character enemy, DamageType damageType, MagicType magicType, double expectedDamage, DamageCalculationOptions? options = null)
+        public DamageRecord DamageToEnemy(Character actor, Character enemy, DamageType damageType, MagicType magicType, double expectedDamage, DamageCalculationOptions? options = null)
         {
-            if (GamingQueue is null) return DamageResult.Evaded;
-            int changeCount = 0;
-            DamageResult result = DamageResult.Normal;
-            double damage = expectedDamage;
-            options ??= new(actor);
-            options.Skill = Skill;
-            if (options.ExpectedDamage == 0) options.ExpectedDamage = expectedDamage;
-            if (options.NeedCalculate && damageType != DamageType.True)
+            if (GamingQueue != null)
             {
-                result = damageType == DamageType.Physical ? GamingQueue.CalculatePhysicalDamage(actor, enemy, false, expectedDamage, out damage, ref changeCount, ref options) : GamingQueue.CalculateMagicalDamage(actor, enemy, false, MagicType, expectedDamage, out damage, ref changeCount, ref options);
+                int changeCount = 0;
+                DamageResult result = DamageResult.Normal;
+                double damage = expectedDamage;
+                options ??= new(actor);
+                options.Skill = Skill;
+                if (options.ExpectedDamage == 0) options.ExpectedDamage = expectedDamage;
+                if (options.NeedCalculate && damageType != DamageType.True)
+                {
+                    result = damageType == DamageType.Physical ? GamingQueue.CalculatePhysicalDamage(actor, enemy, false, expectedDamage, out damage, ref changeCount, ref options) : GamingQueue.CalculateMagicalDamage(actor, enemy, false, MagicType, expectedDamage, out damage, ref changeCount, ref options);
+                }
+                GamingQueue.DamageToEnemy(actor, enemy, damage, false, damageType, magicType, result, options);
+                return options?.GetDamageRecord(damageType, result) ?? new();
             }
-            GamingQueue.DamageToEnemy(actor, enemy, damage, false, damageType, magicType, result, options);
-            return result;
+            return new();
         }
 
         /// <summary>

--- a/Entity/Skill/Skill.cs
+++ b/Entity/Skill/Skill.cs
@@ -385,6 +385,10 @@ namespace Milimoe.FunGame.Core.Entity
             SkillType = type;
             CastAnywhere = SkillType == SkillType.Magic;
             Character = character;
+            if (SkillType == SkillType.SuperSkill)
+            {
+                EPCost = 100;
+            }
         }
 
         /// <summary>
@@ -712,7 +716,7 @@ namespace Milimoe.FunGame.Core.Entity
         public void OnSkillCasting(IGamingQueue queue, Character caster, List<Character> targets, List<Grid> grids)
         {
             GamingQueue = queue;
-            foreach (Effect e in Effects)
+            foreach (Effect e in Effects.OrderByDescending(e => e.Priority))
             {
                 e.GamingQueue = GamingQueue;
                 e.OnSkillCasting(caster, targets, grids);
@@ -722,10 +726,15 @@ namespace Milimoe.FunGame.Core.Entity
         /// <summary>
         /// 技能效果触发前
         /// </summary>
-        public void BeforeSkillCasted()
+        public void BeforeSkillCasted(Character caster, List<Character> targets, List<Grid> grids)
         {
             LastCostMP = RealMPCost;
             LastCostEP = RealEPCost;
+            foreach (Effect e in Effects.OrderByDescending(e => e.Priority))
+            {
+                e.GamingQueue = GamingQueue;
+                e.BeforeSkillCasted(caster, targets, grids, LastCostMP, LastCostEP);
+            }
         }
 
         /// <summary>
@@ -762,10 +771,22 @@ namespace Milimoe.FunGame.Core.Entity
                     }
                 }
             }
-            foreach (Effect e in Effects)
+            foreach (Effect e in Effects.OrderByDescending(e => e.Priority))
             {
                 e.GamingQueue = GamingQueue;
                 e.OnSkillCasted(caster, targets, grids, Values);
+            }
+        }
+
+        /// <summary>
+        /// 技能效果触发后
+        /// </summary>
+        public void AfterSkillCasted(Character caster, List<Character> targets, List<Grid> grids)
+        {
+            foreach (Effect e in Effects.OrderByDescending(e => e.Priority))
+            {
+                e.GamingQueue = GamingQueue;
+                e.AfterSkillCasted(caster, targets, grids);
             }
         }
 
@@ -776,7 +797,7 @@ namespace Milimoe.FunGame.Core.Entity
         /// <param name="targets"></param>
         public void OnSkillCasted(User user, List<Character> targets)
         {
-            foreach (Effect e in Effects)
+            foreach (Effect e in Effects.OrderByDescending(e => e.Priority))
             {
                 e.OnSkillCasted(user, targets, Values);
             }

--- a/Library/Common/Addon/Example/ExampleSkill.cs
+++ b/Library/Common/Addon/Example/ExampleSkill.cs
@@ -324,7 +324,7 @@ namespace Milimoe.FunGame.Core.Library.Common.Addon.Example
             character.ExATK2 += ActualATKBonus;
             character.PhysicalPenetration += ActualPhysicalPenetrationBonus;
             character.ExEvadeRate += ActualEvadeRateBonus;
-            if (character.Effects.FirstOrDefault(e => e is ExamplePassiveSkillEffect) is ExamplePassiveSkillEffect e)
+            if (character.Effects.FirstOrDefault(e => e is ExamplePassiveSkillEffect && e.Skill.Character == character) is ExamplePassiveSkillEffect e)
             {
                 e.CD = 3;
                 if (e.CurrentCD > e.CD) e.CurrentCD = e.CD;
@@ -337,7 +337,7 @@ namespace Milimoe.FunGame.Core.Library.Common.Addon.Example
             character.ExATK2 -= ActualATKBonus;
             character.PhysicalPenetration -= ActualPhysicalPenetrationBonus;
             character.ExEvadeRate -= ActualEvadeRateBonus;
-            if (character.Effects.FirstOrDefault(e => e is ExamplePassiveSkillEffect) is ExamplePassiveSkillEffect e)
+            if (character.Effects.FirstOrDefault(e => e is ExamplePassiveSkillEffect && e.Skill.Character == character) is ExamplePassiveSkillEffect e)
             {
                 e.CD = 10;
             }

--- a/Model/DamageCalculationOptions.cs
+++ b/Model/DamageCalculationOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Milimoe.FunGame.Core.Entity;
+using Milimoe.FunGame.Core.Library.Constant;
 
 namespace Milimoe.FunGame.Core.Model
 {
@@ -73,6 +74,11 @@ namespace Milimoe.FunGame.Core.Model
         public double INT => Character.INT;
 
         /** == 调试数据记录 == **/
+
+        /// <summary>
+        /// 生成伤害记录
+        /// </summary>
+        public DamageRecord GetDamageRecord(DamageType type, DamageResult result) => new(type, result, ExpectedDamage, BeforeDamageBonus, CriticalDamage, DefenseReduction, AfterDamageBonus, MagicEfficacyDamage, FinalDamage, ShieldReduction, ActualDamage);
 
         /// <summary>
         /// 伤害基底（期望）

--- a/Model/DamageRecord.cs
+++ b/Model/DamageRecord.cs
@@ -1,0 +1,100 @@
+﻿using Milimoe.FunGame.Core.Entity;
+using Milimoe.FunGame.Core.Library.Constant;
+
+namespace Milimoe.FunGame.Core.Model
+{
+    /// <summary>
+    /// 记录所有伤害的组成部分
+    /// </summary>
+    public readonly struct DamageRecord
+    {
+        /// <summary>
+        /// 记录所有伤害的组成部分
+        /// </summary>
+        public DamageRecord()
+        {
+            ExpectedDamage = 0;
+            BeforeDamageBonus = [];
+            CriticalDamage = 0;
+            DefenseReduction = 0;
+            AfterDamageBonus = [];
+            MagicEfficacyDamage = 0;
+            FinalDamage = 0;
+            ShieldReduction = 0;
+            ActualDamage = 0;
+        }
+
+        /// <summary>
+        /// 记录所有伤害的组成部分
+        /// </summary>
+        public DamageRecord(DamageType type, DamageResult result, double expectedDamage, Dictionary<Effect, double> beforeDamageBonus, double criticalDamage, double defenseReduction, Dictionary<Effect, double> afterDamageBonus, double magicEfficacyDamage, double finalDamage, double shieldReduction, double actualDamage)
+        {
+            DamageType = type;
+            DamageResult = result;
+            ExpectedDamage = expectedDamage;
+            BeforeDamageBonus = beforeDamageBonus;
+            CriticalDamage = criticalDamage;
+            DefenseReduction = defenseReduction;
+            AfterDamageBonus = afterDamageBonus;
+            MagicEfficacyDamage = magicEfficacyDamage;
+            FinalDamage = finalDamage;
+            ShieldReduction = shieldReduction;
+            ActualDamage = actualDamage;
+        }
+
+        /// <summary>
+        /// 伤害类型
+        /// </summary>
+        public DamageType DamageType { get; } = DamageType.Physical;
+
+        /// <summary>
+        /// 伤害结果
+        /// </summary>
+        public DamageResult DamageResult { get; } = DamageResult.Normal;
+
+        /// <summary>
+        /// 伤害基底（期望）
+        /// </summary>
+        public double ExpectedDamage { get; }
+
+        /// <summary>
+        /// 特效伤害加成记录（乘区1：暴击和减伤计算前）
+        /// </summary>
+        public Dictionary<Effect, double> BeforeDamageBonus { get; }
+
+        /// <summary>
+        /// 暴击伤害
+        /// </summary>
+        public double CriticalDamage { get; }
+
+        /// <summary>
+        /// 伤害减免
+        /// </summary>
+        public double DefenseReduction { get; }
+
+        /// <summary>
+        /// 特效伤害加成记录（乘区2：暴击和减伤计算后）
+        /// </summary>
+        public Dictionary<Effect, double> AfterDamageBonus { get; }
+
+        /// <summary>
+        /// 魔法效能修正
+        /// </summary>
+        public double MagicEfficacyDamage { get; }
+
+        /// <summary>
+        /// 最终伤害
+        /// </summary>
+        public double FinalDamage { get; }
+
+        /// <summary>
+        /// 护盾减免
+        /// </summary>
+        public double ShieldReduction { get; }
+
+        /// <summary>
+        /// 实际造成伤害
+        /// </summary>
+        public double ActualDamage { get; }
+    }
+}

--- a/Model/GamingQueue.cs
+++ b/Model/GamingQueue.cs
@@ -1583,7 +1583,7 @@ namespace Milimoe.FunGame.Core.Model
                                                 effect.AfterCharacterStartCasting(character, skill, targets);
                                             }
 
-                                            skill.BeforeSkillCasted();
+                                            skill.BeforeSkillCasted(character, targets, grids);
 
                                             character.EP -= cost;
                                             baseTime += skill.RealHardnessTime;
@@ -1595,6 +1595,8 @@ namespace Milimoe.FunGame.Core.Model
                                             OnCharacterCastSkillEvent(character, dp, skillTarget, cost);
 
                                             skill.OnSkillCasted(this, character, targets, grids);
+
+                                            skill.AfterSkillCasted(character, targets, grids);
 
                                             effects = [.. character.Effects.Where(e => e.IsInEffect).OrderByDescending(e => e.Priority)];
                                             foreach (Effect effect in effects)
@@ -1659,7 +1661,7 @@ namespace Milimoe.FunGame.Core.Model
                                 LastRound.ActionTypes.Add(CharacterActionType.CastSkill);
                                 _castingSkills.Remove(character);
 
-                                skill.BeforeSkillCasted();
+                                skill.BeforeSkillCasted(character, targets, grids);
 
                                 character.MP -= cost;
                                 baseTime += skill.RealHardnessTime;
@@ -1671,6 +1673,8 @@ namespace Milimoe.FunGame.Core.Model
                                 OnCharacterCastSkillEvent(character, dp, skillTarget, cost);
 
                                 skill.OnSkillCasted(this, character, targets, grids);
+
+                                skill.AfterSkillCasted(character, targets, grids);
 
                                 effects = [.. character.Effects.Where(e => e.IsInEffect).OrderByDescending(e => e.Priority)];
                                 foreach (Effect effect in effects)
@@ -1730,7 +1734,7 @@ namespace Milimoe.FunGame.Core.Model
                             CheckSkilledImmune(character, targets, skill);
                             LastRound.Targets[CharacterActionType.CastSuperSkill] = [.. targets];
 
-                            skill.BeforeSkillCasted();
+                            skill.BeforeSkillCasted(character, targets, grids);
 
                             character.EP -= cost;
                             baseTime += skill.RealHardnessTime;
@@ -1743,6 +1747,8 @@ namespace Milimoe.FunGame.Core.Model
                             OnCharacterCastSkillEvent(character, dp, skillTarget, cost);
 
                             skill.OnSkillCasted(this, character, targets, grids);
+
+                            skill.AfterSkillCasted(character, targets, grids);
 
                             effects = [.. character.Effects.Where(e => e.IsInEffect).OrderByDescending(e => e.Priority)];
                             foreach (Effect effect in effects)
@@ -3106,7 +3112,7 @@ namespace Milimoe.FunGame.Core.Model
                             effect.AfterCharacterStartCasting(character, skill, targets);
                         }
 
-                        skill.BeforeSkillCasted();
+                        skill.BeforeSkillCasted(character, targets, grids);
 
                         skill.CurrentCD = skill.RealCD;
                         skill.Enable = false;
@@ -3134,6 +3140,8 @@ namespace Milimoe.FunGame.Core.Model
                         OnCharacterCastItemSkillEvent(character, dp, item, skillTarget, costMP, costEP);
 
                         skill.OnSkillCasted(this, character, targets, grids);
+
+                        skill.AfterSkillCasted(character, targets, grids);
 
                         effects = [.. character.Effects.Where(e => e.IsInEffect).OrderByDescending(e => e.Priority)];
                         foreach (Effect effect in effects)

--- a/Model/PrefabricatedEntity/CourageCommandSkill.cs
+++ b/Model/PrefabricatedEntity/CourageCommandSkill.cs
@@ -1,11 +1,12 @@
 ﻿using Milimoe.FunGame.Core.Entity;
+using Milimoe.FunGame.Core.Library.Constant;
 
 namespace Milimoe.FunGame.Core.Model.PrefabricatedEntity
 {
     /// <summary>
     /// 继承此类以表示勇气指令技能
     /// </summary>
-    public class CourageCommandSkill(long id, string name, Dictionary<string, object> args, Character? character = null) : OpenSkill(id, name, args, character)
+    public abstract class CourageCommandSkill(Character? character = null) : Skill(SkillType.Skill, character)
     {
 
     }

--- a/Model/PrefabricatedEntity/MagicCardPack.cs
+++ b/Model/PrefabricatedEntity/MagicCardPack.cs
@@ -6,7 +6,7 @@ namespace Milimoe.FunGame.Core.Model.PrefabricatedEntity
     /// <summary>
     /// 魔法卡包的基础实现
     /// </summary>
-    public class MagicCardPack : OpenItem
+    public class MagicCardPack : Item
     {
         public override ItemType ItemType => ItemType.MagicCardPack;
 
@@ -50,10 +50,12 @@ namespace Milimoe.FunGame.Core.Model.PrefabricatedEntity
         /// </summary>
         private PrimaryAttribute _originalAttribute = PrimaryAttribute.None;
 
-        public MagicCardPack(long id, string name, Dictionary<string, object> args) : base(id, name, args)
+        public MagicCardPack(Dictionary<string, object>? args = null) : base(ItemType.MagicCardPack)
         {
+            args ??= [];
             foreach (string key in args.Keys)
             {
+                Others[key] = args[key];
                 switch (key.ToLower())
                 {
                     case "exstr":

--- a/Model/PrefabricatedEntity/NeuralCalibrationEffect.cs
+++ b/Model/PrefabricatedEntity/NeuralCalibrationEffect.cs
@@ -6,7 +6,7 @@ namespace Milimoe.FunGame.Core.Model.PrefabricatedEntity
     /// <summary>
     /// 继承此类以表示神经校准特效
     /// </summary>
-    public class NeuralCalibrationEffect : Effect
+    public abstract class NeuralCalibrationEffect : Effect
     {
         public WeaponType SupportedWeaponType { get; set; } = WeaponType.None;
     }

--- a/Model/PrefabricatedEntity/SoulboundSkill.cs
+++ b/Model/PrefabricatedEntity/SoulboundSkill.cs
@@ -1,18 +1,62 @@
 ﻿using Milimoe.FunGame.Core.Entity;
+using Milimoe.FunGame.Core.Library.Common.Addon;
+using Milimoe.FunGame.Core.Library.Constant;
 
 namespace Milimoe.FunGame.Core.Model.PrefabricatedEntity
 {
     /// <summary>
     /// 继承此类以表示灵魂绑定技能
     /// </summary>
-    public class SoulboundSkill(long id, string name, Dictionary<string, object> args, Character? character = null) : OpenSkill(id, name, args, character)
+    /// <remarks>
+    /// 灵魂绑定：一个至少消耗 100 能量、每额外消耗 20 能量效果增强 10% 的爆发技
+    /// </remarks>
+    /// <param name="character"></param>
+    public abstract class SoulboundSkill(Character? character = null) : Skill(SkillType.SuperSkill, character)
     {
         public override bool CostAllEP => true;
         public override double MinCostEP => 100;
+    }
+
+    /// <summary>
+    /// 灵魂绑定专有特效
+    /// </summary>
+    public abstract class SoulboundEffect(SoulboundSkill skill) : Effect(skill)
+    {
+        /// <summary>
+        /// 所属的灵魂绑定技能
+        /// </summary>
+        public SoulboundSkill SoulboundSkill => skill;
 
         /// <summary>
-        /// 每额外消耗 20 能量效果增强 10%
+        /// 增强系数，每额外消耗 20 能量效果增强 10%
         /// </summary>
-        public virtual double Improvement => (LastCostEP - MinCostEP) / 20 * 0.1;
+        public double Improvement
+        {
+            get
+            {
+                double improvement = 0;
+                if (_improvement != null)
+                {
+                    improvement = _improvement.Value;
+                }
+                else if (Skill.Character != null)
+                {
+                    improvement = (Skill.Character.EP - skill.MinCostEP) / 20.0 * 0.1;
+                }
+                return improvement;
+            }
+        }
+
+        private double? _improvement = null;
+
+        public override void BeforeSkillCasted(Character caster, List<Character> targets, List<Grid> grids, double mpCost = 0, double epCost = 0)
+        {
+            _improvement = (epCost - skill.MinCostEP) / 20.0 * 0.1;
+        }
+
+        public override void AfterSkillCasted(Character caster, List<Character> targets, List<Grid> grids)
+        {
+            _improvement = null;
+        }
     }
 }


### PR DESCRIPTION
DamageRecord 是一个只读结构体，在 Effect 的 DamageToEnemy 方法里作为返回值提供，包含所有的分步伤害计算结果