### PR TITLE
回合记录的结构快照改进

### DIFF
--- a/Api/BattleStatePredictor.cs
+++ b/Api/BattleStatePredictor.cs
@@ -1,0 +1,182 @@
+using FunGame.Core.Entity;
+using FunGame.Core.Library.Constant;
+using FunGame.Core.Model.Framework;
+
+namespace FunGame.Core.Api
+{
+    /// <summary>
+    /// 状态预测器<para/>
+    /// 基于"定期检查点 + 事件流推算"：从目标回合之前的最近状态检查点出发，沿事件流与 <see cref="RoundRecord.TotalTime"/> 时间轴推算角色状态；<para/>
+    /// 供回放/观战展示 HP/MP/EP、装备、技能冷却、状态栏特效。允许由特效钩子（如回复量修改）导致的小误差，在下一个检查点自动校正。
+    /// </summary>
+    public static class BattleStatePredictor
+    {
+        /// <summary>
+        /// 推算指定回合结束时所有角色的状态（key 为角色 Guid）
+        /// </summary>
+        /// <param name="rounds">全部回合记录</param>
+        /// <param name="targetRound">目标回合号</param>
+        /// <returns>角色 Guid -> 状态快照；目标回合前无检查点（或角色不在检查点中）时为空/缺失</returns>
+        public static Dictionary<Guid, CharacterStateSnapshot> PredictAll(IEnumerable<RoundRecord> rounds, int targetRound)
+        {
+            Dictionary<Guid, CharacterStateSnapshot> states = [];
+            List<RoundRecord> ordered = [.. rounds.OrderBy(r => r.Round).DistinctBy(r => r.Round)];
+            // 基准 = 目标回合之前（不含）的最近检查点，保证目标回合自身是检查点时仍以上一检查点为推算基准
+            RoundRecord? baseRound = ordered.LastOrDefault(r => r.Round < targetRound && r.Checkpoint != null);
+            if (baseRound?.Checkpoint == null)
+            {
+                return states;
+            }
+
+            foreach (CharacterStateSnapshot cp in baseRound.Checkpoint)
+            {
+                if (cp.Character == null || cp.Character.Guid == Guid.Empty) continue;
+                states[cp.Character.Guid] = Copy(cp);
+            }
+
+            double prevTime = baseRound.TotalTime;
+            foreach (RoundRecord round in ordered.Where(r => r.Round > baseRound.Round && r.Round <= targetRound))
+            {
+                double currentTime = round.TotalTime;
+                double elapsed = Math.Max(0, currentTime - prevTime);
+
+                // 时间流逝：自动回复（存活角色按 HR/MR × 时间），技能冷却与特效剩余时间沿时间轴递减
+                foreach (CharacterStateSnapshot state in states.Values)
+                {
+                    if (state.HP > 0)
+                    {
+                        state.HP = Math.Min(state.MaxHP, state.HP + state.HR * elapsed);
+                        state.MP = Math.Min(state.MaxMP, state.MP + state.MR * elapsed);
+                    }
+                    foreach (SkillStateSnapshot skill in state.Skills)
+                    {
+                        skill.CurrentCD = Math.Max(0, skill.CurrentCD - elapsed);
+                    }
+                    foreach (EffectStateSnapshot effect in state.Effects)
+                    {
+                        effect.RemainDuration = Math.Max(0, effect.RemainDuration - elapsed);
+                        // 按回合递减的特效每经过一个回合减少 1
+                        if (effect.RemainDurationTurn > 0) effect.RemainDurationTurn--;
+                    }
+                }
+
+                // 应用本回合操作事件
+                foreach (ActionRecord action in round.Actions)
+                {
+                    ApplyAction(action, states);
+                }
+
+                // 复活
+                foreach (Character character in round.Respawns)
+                {
+                    if (states.TryGetValue(character.Guid, out CharacterStateSnapshot? respawnState))
+                    {
+                        respawnState.HP = respawnState.MaxHP;
+                    }
+                }
+
+                prevTime = currentTime;
+            }
+
+            return states;
+        }
+
+        /// <summary>
+        /// 推算指定回合结束时单个角色的状态
+        /// </summary>
+        /// <param name="rounds">全部回合记录</param>
+        /// <param name="targetRound">目标回合号</param>
+        /// <param name="characterGuid">角色 Guid</param>
+        /// <returns>状态快照；无检查点基准或角色不在基准中时为 null</returns>
+        public static CharacterStateSnapshot? Predict(IEnumerable<RoundRecord> rounds, int targetRound, Guid characterGuid)
+        {
+            return PredictAll(rounds, targetRound).TryGetValue(characterGuid, out CharacterStateSnapshot? state) ? state : null;
+        }
+
+        /// <summary>
+        /// 将单次操作事件应用到状态集合（伤害/治疗/消耗/技能冷却/新施加特效）
+        /// </summary>
+        private static void ApplyAction(ActionRecord action, Dictionary<Guid, CharacterStateSnapshot> states)
+        {
+            if (action.Actor == null || !states.TryGetValue(action.Actor.Guid, out CharacterStateSnapshot? actorState))
+            {
+                return;
+            }
+
+            // MP/EP 消耗
+            actorState.MP = Math.Max(0, actorState.MP - action.MPCost);
+            actorState.EP = Math.Max(0, actorState.EP - action.EPCost);
+
+            // 技能冷却重置（同一技能多次释放取最近一次）
+            if (action.Skill != null && action.SkillCD > 0)
+            {
+                SkillStateSnapshot? skillState = actorState.Skills.FirstOrDefault(s => s.SkillId == action.Skill.Id);
+                skillState?.CurrentCD = action.SkillCD;
+            }
+
+            // 伤害
+            foreach (KeyValuePair<Character, double> kv in action.Damages)
+            {
+                if (states.TryGetValue(kv.Key.Guid, out CharacterStateSnapshot? targetState))
+                {
+                    targetState.HP = Math.Max(0, targetState.HP - kv.Value);
+                }
+            }
+
+            // 治疗
+            foreach (KeyValuePair<Character, double> kv in action.Heals)
+            {
+                if (states.TryGetValue(kv.Key.Guid, out CharacterStateSnapshot? targetState))
+                {
+                    targetState.HP = Math.Min(targetState.MaxHP, targetState.HP + kv.Value);
+                }
+            }
+
+            // 窗口内新施加的特效（展示级：仅记录类型，剩余时间依赖下一个检查点校正）
+            foreach (KeyValuePair<Character, List<EffectType>> kv in action.ApplyEffects)
+            {
+                if (states.TryGetValue(kv.Key.Guid, out CharacterStateSnapshot? targetState))
+                {
+                    foreach (EffectType type in kv.Value)
+                    {
+                        if (targetState.Effects.All(e => e.EffectType != type))
+                        {
+                            targetState.Effects.Add(new EffectStateSnapshot { EffectType = type });
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// 深拷贝状态快照（预测时基于副本推算，不修改检查点数据）
+        /// </summary>
+        private static CharacterStateSnapshot Copy(CharacterStateSnapshot source)
+        {
+            CharacterStateSnapshot copy = new()
+            {
+                Character = source.Character,
+                HP = source.HP,
+                MaxHP = source.MaxHP,
+                MP = source.MP,
+                MaxMP = source.MaxMP,
+                EP = source.EP,
+                HR = source.HR,
+                MR = source.MR
+            };
+            foreach (KeyValuePair<EquipSlotType, long> kv in source.Equipments)
+            {
+                copy.Equipments[kv.Key] = kv.Value;
+            }
+            foreach (SkillStateSnapshot skill in source.Skills)
+            {
+                copy.Skills.Add(new SkillStateSnapshot { SkillId = skill.SkillId, SkillName = skill.SkillName, Level = skill.Level, CurrentCD = skill.CurrentCD });
+            }
+            foreach (EffectStateSnapshot effect in source.Effects)
+            {
+                copy.Effects.Add(new EffectStateSnapshot { EffectId = effect.EffectId, EffectName = effect.EffectName, EffectType = effect.EffectType, RemainDuration = effect.RemainDuration, RemainDurationTurn = effect.RemainDurationTurn });
+            }
+            return copy;
+        }
+    }
+}

--- a/Api/JsonService.cs
+++ b/Api/JsonService.cs
@@ -22,7 +22,7 @@ namespace FunGame.Core.Api
                 new CharacterConverter(), new MagicResistanceConverter(), new EquipSlotConverter(), new SkillConverter(), new EffectConverter(), new ItemConverter(),
                 new InventoryConverter(), new NormalAttackConverter(), new ClubConverter(), new GoodsConverter(), new StoreConverter(),
                 new NovelOptionConverter(), new NovelNodeConverter(), new NovelCharacterNodeConverter(), new ShieldConverter(), new RoundRecordConverter(), new ActivityConverter(),
-                new QuestConverter(), new MarketConverter(), new MarketItemConverter()
+                new QuestConverter(), new MarketConverter(), new MarketItemConverter(), new ActionRecordConverter(), new CharacterStateSnapshotConverter()
             }
         };
 

--- a/Api/JsonService.cs
+++ b/Api/JsonService.cs
@@ -22,7 +22,7 @@ namespace FunGame.Core.Api
                 new CharacterConverter(), new MagicResistanceConverter(), new EquipSlotConverter(), new SkillConverter(), new EffectConverter(), new ItemConverter(),
                 new InventoryConverter(), new NormalAttackConverter(), new ClubConverter(), new GoodsConverter(), new StoreConverter(),
                 new NovelOptionConverter(), new NovelNodeConverter(), new NovelCharacterNodeConverter(), new ShieldConverter(), new RoundRecordConverter(), new ActivityConverter(),
-                new QuestConverter(), new MarketConverter(), new MarketItemConverter(), new ActionRecordConverter(), new CharacterStateSnapshotConverter()
+                new QuestConverter(), new MarketConverter(), new MarketItemConverter(), new ActionRecordConverter(), new CharacterStateSnapshotConverter(), new RankingEntryConverter()
             }
         };
 

--- a/Api/RoundRecordRenderer.cs
+++ b/Api/RoundRecordRenderer.cs
@@ -1,0 +1,109 @@
+using System.Text;
+using FunGame.Core.Entity;
+using FunGame.Core.Model.Framework;
+
+namespace FunGame.Core.Api
+{
+    /// <summary>
+    /// 展示型回放渲染器<para/>
+    /// 只读取回合/操作记录数据渲染文本（不重跑引擎），供复盘、观战等消费端使用
+    /// </summary>
+    public static class RoundRecordRenderer
+    {
+        /// <summary>
+        /// 渲染单个回合的完整文本（操作流 + 回合汇总）
+        /// </summary>
+        /// <param name="round">回合记录</param>
+        /// <returns></returns>
+        public static string RenderRound(RoundRecord round)
+        {
+            StringBuilder builder = new();
+            builder.AppendLine($"=== Round {round.Round} ===");
+            builder.AppendLine($"[ {round.Actor} ] 的回合");
+
+            // 操作流（DP 系统下逐条操作，按执行顺序）
+            foreach (ActionRecord action in round.Actions)
+            {
+                builder.AppendLine("  " + action);
+            }
+
+            // 回合汇总
+            if (round.RoundRewards.Count > 0)
+            {
+                builder.AppendLine($"[ {round.Actor} ] 回合奖励 -> {string.Join(" / ", round.RoundRewards.Select(s => s.Name)).Trim()}");
+            }
+            if (round.DeathContinuousKilling.Count > 0)
+            {
+                builder.AppendLine(string.Join("\r\n", round.DeathContinuousKilling));
+            }
+            if (round.ActorContinuousKilling.Count > 0)
+            {
+                builder.AppendLine(string.Join("\r\n", round.ActorContinuousKilling));
+            }
+            if (round.Assists.Count > 0)
+            {
+                builder.AppendLine($"本回合助攻：[ {string.Join(" ] / [ ", round.Assists)} ]");
+            }
+            if (round.OtherMessages.Count > 0)
+            {
+                builder.AppendLine(string.Join("\r\n", round.OtherMessages));
+            }
+
+            if (round.CastTime > 0)
+            {
+                builder.AppendLine($"[ {round.Actor} ] 吟唱持续时间：{round.CastTime:0.##}");
+            }
+            else
+            {
+                builder.AppendLine($"[ {round.Actor} ] 回合结束，硬直时间：{round.HardnessTime:0.##}");
+            }
+
+            foreach (Character character in round.RespawnCountdowns.Keys)
+            {
+                builder.AppendLine($"[ {character} ] 进入复活倒计时：{round.RespawnCountdowns[character]:0.##}");
+            }
+
+            foreach (Character character in round.Respawns)
+            {
+                builder.AppendLine($"[ {character} ] 复活了");
+            }
+
+            return builder.ToString().TrimEnd();
+        }
+
+        /// <summary>
+        /// 渲染整个对局的所有回合
+        /// </summary>
+        /// <param name="rounds">全部回合记录（按顺序）</param>
+        /// <returns></returns>
+        public static string RenderAll(IEnumerable<RoundRecord> rounds)
+        {
+            StringBuilder builder = new();
+            foreach (RoundRecord round in rounds)
+            {
+                builder.AppendLine(RenderRound(round));
+                builder.AppendLine();
+            }
+            return builder.ToString().TrimEnd();
+        }
+
+        /// <summary>
+        /// 渲染指定角色的全部操作（按角色过滤）
+        /// </summary>
+        /// <param name="rounds">全部回合记录</param>
+        /// <param name="character">目标角色（按 Guid 匹配）</param>
+        /// <returns></returns>
+        public static string RenderCharacterActions(IEnumerable<RoundRecord> rounds, Character character)
+        {
+            StringBuilder builder = new();
+            foreach (RoundRecord round in rounds)
+            {
+                foreach (ActionRecord action in round.Actions.Where(a => a.Actor.Guid == character.Guid))
+                {
+                    builder.AppendLine($"[Round {round.Round}] " + action);
+                }
+            }
+            return builder.ToString().TrimEnd();
+        }
+    }
+}

--- a/Entity/Character/Character.cs
+++ b/Entity/Character/Character.cs
@@ -1350,6 +1350,14 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
+        /// 与 <see cref="Equals(IBaseEntity?)"/> 保持一致（字典默认比较器使用 <see cref="object.Equals(object?)"/>）
+        /// </summary>
+        public override bool Equals(object? obj)
+        {
+            return obj is IBaseEntity other && Equals(other);
+        }
+
+        /// <summary>
         /// 获取角色的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 <see cref="ToString()"/>）
         /// </summary>
         /// <returns></returns>

--- a/Entity/Character/Character.cs
+++ b/Entity/Character/Character.cs
@@ -1350,6 +1350,15 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
+        /// 获取角色的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 <see cref="ToString()"/>）
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return ToString().GetHashCode();
+        }
+
+        /// <summary>
         /// 获取角色实例的昵称以及所属玩家，如果没有昵称，则用名字代替
         /// </summary>
         /// <returns></returns>

--- a/Entity/Item/Item.cs
+++ b/Entity/Item/Item.cs
@@ -649,6 +649,14 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
+        /// 与 <see cref="Equals(IBaseEntity?)"/> 保持一致（字典默认比较器使用 <see cref="object.Equals(object?)"/>）
+        /// </summary>
+        public override bool Equals(object? obj)
+        {
+            return obj is IBaseEntity other && Equals(other);
+        }
+
+        /// <summary>
         /// 获取物品的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Id.Name）
         /// </summary>
         /// <returns></returns>

--- a/Entity/Item/Item.cs
+++ b/Entity/Item/Item.cs
@@ -649,6 +649,15 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
+        /// 获取物品的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Id.Name）
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return GetIdName().GetHashCode();
+        }
+
+        /// <summary>
         /// 设置一些属性给从工厂构造出来的 <paramref name="newbyFactory"/> 对象
         /// </summary>
         /// <param name="newbyFactory"></param>

--- a/Entity/Skill/Effect.cs
+++ b/Entity/Skill/Effect.cs
@@ -1391,7 +1391,15 @@ namespace FunGame.Core.Entity
         /// </summary>
         /// <param name="character"></param>
         /// <param name="types"></param>
-        public void RecordCharacterApplyEffects(Character character, params List<EffectType> types) => GamingQueue?.LastRound.AddApplyEffects(character, types);
+        public void RecordCharacterApplyEffects(Character character, params List<EffectType> types)
+        {
+            if (GamingQueue == null) return;
+            GamingQueue.LastRound.AddApplyEffects(character, types);
+            if (GamingQueue.CurrentAction is ActionRecord action)
+            {
+                action.AddApplyEffects(character, types);
+            }
+        }
 
         /// <summary>
         /// 返回特效详情

--- a/Entity/Skill/Skill.cs
+++ b/Entity/Skill/Skill.cs
@@ -1006,6 +1006,14 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
+        /// 与 <see cref="Equals(IBaseEntity?)"/> 保持一致（字典默认比较器使用 <see cref="object.Equals(object?)"/>）
+        /// </summary>
+        public override bool Equals(object? obj)
+        {
+            return obj is IBaseEntity other && Equals(other);
+        }
+
+        /// <summary>
         /// 获取技能的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Id.Name）
         /// </summary>
         /// <returns></returns>

--- a/Entity/Skill/Skill.cs
+++ b/Entity/Skill/Skill.cs
@@ -1006,6 +1006,15 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
+        /// 获取技能的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Id.Name）
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return GetIdName().GetHashCode();
+        }
+
+        /// <summary>
         /// 复制一个技能
         /// </summary>
         /// <returns></returns>

--- a/Interface/Base/IGamingQueue.cs
+++ b/Interface/Base/IGamingQueue.cs
@@ -40,6 +40,11 @@ namespace FunGame.Core.Interface.Base
         public RoundRecord LastRound { get; set; }
 
         /// <summary>
+        /// 当前正在执行的操作记录
+        /// </summary>
+        public ActionRecord? CurrentAction { get; }
+
+        /// <summary>
         /// 所有回合的记录
         /// </summary>
         public List<RoundRecord> Rounds { get; }

--- a/Interface/Base/IRoundRecordSink.cs
+++ b/Interface/Base/IRoundRecordSink.cs
@@ -1,0 +1,23 @@
+using FunGame.Core.Model.Framework;
+
+namespace FunGame.Core.Interface.Base
+{
+    /// <summary>
+    /// 回合记录外发通道<para/>
+    /// 实现方负责将记录序列化并发送（如 POST 到远程服务、写入消息队列等）
+    /// </summary>
+    public interface IRoundRecordSink
+    {
+        /// <summary>
+        /// 外发单次操作记录（操作完成后即时调用，用于实时增量推送）
+        /// </summary>
+        /// <param name="action">操作记录（结构快照，实体引用共享）</param>
+        void SendAction(ActionRecord action);
+
+        /// <summary>
+        /// 外发回合记录（回合决策完成后调用，包含本回合操作流与回合汇总）
+        /// </summary>
+        /// <param name="round">回合记录（结构快照，实体引用共享）</param>
+        void SendRound(RoundRecord round);
+    }
+}

--- a/Library/Common/JsonConverter/ActionRecordConverter.cs
+++ b/Library/Common/JsonConverter/ActionRecordConverter.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using FunGame.Core.Api;
+using FunGame.Core.Entity;
+using FunGame.Core.Library.Architecture;
+using FunGame.Core.Library.Constant;
+using FunGame.Core.Model.Framework;
+
+namespace FunGame.Core.Library.Common.JsonConverter
+{
+    public class ActionRecordConverter : BaseEntityConverter<ActionRecord>
+    {
+        /// <summary>
+        /// 序列化时额外输出的角色引用集合属性名，用于反序列化时恢复以角色为 key 的字典
+        /// </summary>
+        private const string AllCharactersProperty = "AllCharacters";
+
+        public override ActionRecord NewInstance()
+        {
+            return new ActionRecord(0);
+        }
+
+        public override void ReadPropertyName(ref Utf8JsonReader reader, string propertyName, JsonSerializerOptions options, ref ActionRecord result, Dictionary<string, object> convertingContext)
+        {
+            switch (propertyName)
+            {
+                case nameof(ActionRecord.Round):
+                    result.Round = reader.GetInt32();
+                    break;
+                case AllCharactersProperty:
+                    convertingContext[AllCharactersProperty] = CharacterRefHelper.ReadList(ref reader);
+                    break;
+                case nameof(ActionRecord.Actor):
+                    result.Actor = CharacterRefHelper.Read(ref reader);
+                    break;
+                case nameof(ActionRecord.ActionIndex):
+                    result.ActionIndex = reader.GetInt32();
+                    break;
+                case nameof(ActionRecord.ActionType):
+                    result.ActionType = (CharacterActionType)reader.GetInt32();
+                    break;
+                case nameof(ActionRecord.Skill):
+                    result.Skill = SkillRefHelper.Read(ref reader);
+                    break;
+                case nameof(ActionRecord.Item):
+                    result.Item = ItemRefHelper.Read(ref reader);
+                    break;
+                case nameof(ActionRecord.Cost):
+                    result.Cost = reader.GetString() ?? "";
+                    break;
+                case nameof(ActionRecord.MPCost):
+                    result.MPCost = reader.GetDouble();
+                    break;
+                case nameof(ActionRecord.EPCost):
+                    result.EPCost = reader.GetDouble();
+                    break;
+                case nameof(ActionRecord.SkillCD):
+                    result.SkillCD = reader.GetDouble();
+                    break;
+                case nameof(ActionRecord.DecisionPointsCost):
+                    result.DecisionPointsCost = reader.GetDouble();
+                    break;
+                case nameof(ActionRecord.Targets):
+                    result.Targets.AddRange(CharacterRefHelper.ReadList(ref reader));
+                    break;
+                case nameof(ActionRecord.Damages):
+                    convertingContext[nameof(ActionRecord.Damages)] = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
+                    break;
+                case nameof(ActionRecord.IsCritical):
+                    convertingContext[nameof(ActionRecord.IsCritical)] = JsonService.GetObject<Dictionary<Guid, bool>>(ref reader, options) ?? [];
+                    break;
+                case nameof(ActionRecord.IsEvaded):
+                    convertingContext[nameof(ActionRecord.IsEvaded)] = JsonService.GetObject<Dictionary<Guid, bool>>(ref reader, options) ?? [];
+                    break;
+                case nameof(ActionRecord.IsImmune):
+                    convertingContext[nameof(ActionRecord.IsImmune)] = JsonService.GetObject<Dictionary<Guid, bool>>(ref reader, options) ?? [];
+                    break;
+                case nameof(ActionRecord.Heals):
+                    convertingContext[nameof(ActionRecord.Heals)] = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
+                    break;
+                case nameof(ActionRecord.ApplyEffects):
+                    convertingContext[nameof(ActionRecord.ApplyEffects)] = JsonService.GetObject<Dictionary<Guid, List<EffectType>>>(ref reader, options) ?? [];
+                    break;
+                case nameof(ActionRecord.Messages):
+                    result.Messages.AddRange(JsonService.GetObject<List<string>>(ref reader, options) ?? []);
+                    break;
+                case nameof(ActionRecord.IsSuccess):
+                    result.IsSuccess = reader.GetBoolean();
+                    break;
+                case nameof(ActionRecord.FailReason):
+                    result.FailReason = reader.GetString() ?? "";
+                    break;
+                case nameof(ActionRecord.CastTime):
+                    result.CastTime = reader.GetDouble();
+                    break;
+                case nameof(ActionRecord.HardnessTime):
+                    result.HardnessTime = reader.GetDouble();
+                    break;
+
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        public override void AfterConvert(ref ActionRecord result, Dictionary<string, object> convertingContext)
+        {
+            ActionRecord record = result;
+            List<Character>? allCharacters = convertingContext.TryGetValue(AllCharactersProperty, out object? ac) ? ac as List<Character> : null;
+
+            ResolveKeyed<double>(record, convertingContext, nameof(ActionRecord.Damages), allCharacters, (c, v) => record.Damages[c] = v);
+            ResolveKeyed<bool>(record, convertingContext, nameof(ActionRecord.IsCritical), allCharacters, (c, v) => record.IsCritical[c] = v);
+            ResolveKeyed<bool>(record, convertingContext, nameof(ActionRecord.IsEvaded), allCharacters, (c, v) => record.IsEvaded[c] = v);
+            ResolveKeyed<bool>(record, convertingContext, nameof(ActionRecord.IsImmune), allCharacters, (c, v) => record.IsImmune[c] = v);
+            ResolveKeyed<double>(record, convertingContext, nameof(ActionRecord.Heals), allCharacters, (c, v) => record.Heals[c] = v);
+            ResolveKeyed<List<EffectType>>(record, convertingContext, nameof(ActionRecord.ApplyEffects), allCharacters, (c, v) => record.ApplyEffects[c] = v);
+        }
+
+        private static void ResolveKeyed<T>(ActionRecord record, Dictionary<string, object> convertingContext, string propertyName, List<Character>? allCharacters, Action<Character, T> set)
+        {
+            if (convertingContext.TryGetValue(propertyName, out object? raw) && raw is Dictionary<Guid, T> dict)
+            {
+                foreach (KeyValuePair<Guid, T> kvp in dict)
+                {
+                    Character? character = FindCharacterByGuid(kvp.Key, record, allCharacters);
+                    if (character != null) set(character, kvp.Value);
+                }
+            }
+        }
+
+        private static Character? FindCharacterByGuid(Guid guid, ActionRecord record, List<Character>? allCharacters)
+        {
+            if (allCharacters != null)
+            {
+                Character? character = allCharacters.FirstOrDefault(c => c.Guid == guid);
+                if (character != null) return character;
+            }
+
+            // 兼容旧数据（无 AllCharacters 字段）：从 Targets/Actor 中查找
+            Character? fallback = record.Targets.FirstOrDefault(c => c.Guid == guid);
+            if (fallback != null) return fallback;
+            if (record.Actor != null && record.Actor.Guid == guid) return record.Actor;
+            return null;
+        }
+
+        public override void Write(Utf8JsonWriter writer, ActionRecord value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber(nameof(ActionRecord.Round), value.Round);
+            // 收集所有涉及的角色引用（含仅出现在结果字典 key 中的角色，如反弹/反击伤害目标）
+            List<Character> allCharacters = [value.Actor, .. value.Targets, .. value.Damages.Keys, .. value.Heals.Keys, .. value.IsCritical.Keys, .. value.IsEvaded.Keys, .. value.IsImmune.Keys];
+            allCharacters.AddRange([.. value.ApplyEffects.Keys]);
+            allCharacters = [.. allCharacters.Where(c => c != null && c.Guid != Guid.Empty).DistinctBy(c => c.Guid)];
+            writer.WritePropertyName(AllCharactersProperty);
+            CharacterRefHelper.WriteList(writer, allCharacters);
+            writer.WritePropertyName(nameof(ActionRecord.Actor));
+            CharacterRefHelper.Write(writer, value.Actor);
+            writer.WriteNumber(nameof(ActionRecord.ActionIndex), value.ActionIndex);
+            writer.WriteNumber(nameof(ActionRecord.ActionType), (int)value.ActionType);
+            writer.WritePropertyName(nameof(ActionRecord.Skill));
+            SkillRefHelper.Write(writer, value.Skill);
+            writer.WritePropertyName(nameof(ActionRecord.Item));
+            ItemRefHelper.Write(writer, value.Item);
+            writer.WriteString(nameof(ActionRecord.Cost), value.Cost);
+            writer.WriteNumber(nameof(ActionRecord.MPCost), value.MPCost);
+            writer.WriteNumber(nameof(ActionRecord.EPCost), value.EPCost);
+            writer.WriteNumber(nameof(ActionRecord.SkillCD), value.SkillCD);
+            writer.WriteNumber(nameof(ActionRecord.DecisionPointsCost), value.DecisionPointsCost);
+            writer.WritePropertyName(nameof(ActionRecord.Targets));
+            CharacterRefHelper.WriteList(writer, value.Targets);
+            writer.WritePropertyName(nameof(ActionRecord.Damages));
+            JsonSerializer.Serialize(writer, value.Damages.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
+            writer.WritePropertyName(nameof(ActionRecord.IsCritical));
+            JsonSerializer.Serialize(writer, value.IsCritical.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
+            writer.WritePropertyName(nameof(ActionRecord.IsEvaded));
+            JsonSerializer.Serialize(writer, value.IsEvaded.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
+            writer.WritePropertyName(nameof(ActionRecord.IsImmune));
+            JsonSerializer.Serialize(writer, value.IsImmune.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
+            writer.WritePropertyName(nameof(ActionRecord.Heals));
+            JsonSerializer.Serialize(writer, value.Heals.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
+            writer.WritePropertyName(nameof(ActionRecord.ApplyEffects));
+            JsonSerializer.Serialize(writer, value.ApplyEffects.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
+            writer.WritePropertyName(nameof(ActionRecord.Messages));
+            JsonSerializer.Serialize(writer, value.Messages, options);
+            writer.WriteBoolean(nameof(ActionRecord.IsSuccess), value.IsSuccess);
+            writer.WriteString(nameof(ActionRecord.FailReason), value.FailReason);
+            writer.WriteNumber(nameof(ActionRecord.CastTime), value.CastTime);
+            writer.WriteNumber(nameof(ActionRecord.HardnessTime), value.HardnessTime);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/Library/Common/JsonConverter/CharacterStateSnapshotConverter.cs
+++ b/Library/Common/JsonConverter/CharacterStateSnapshotConverter.cs
@@ -48,6 +48,9 @@ namespace FunGame.Core.Library.Common.JsonConverter
                         result.Equipments[(EquipSlotType)kvp.Key] = kvp.Value;
                     }
                     break;
+                case nameof(CharacterStateSnapshot.EquipmentsDetail):
+                    result.EquipmentsDetail.AddRange(JsonService.GetObject<List<EquipmentStateSnapshot>>(ref reader, options) ?? []);
+                    break;
                 case nameof(CharacterStateSnapshot.Skills):
                     result.Skills.AddRange(JsonService.GetObject<List<SkillStateSnapshot>>(ref reader, options) ?? []);
                     break;
@@ -78,6 +81,8 @@ namespace FunGame.Core.Library.Common.JsonConverter
             writer.WriteNumber(nameof(CharacterStateSnapshot.MR), value.MR);
             writer.WritePropertyName(nameof(CharacterStateSnapshot.Equipments));
             JsonSerializer.Serialize(writer, value.Equipments.ToDictionary(kv => (int)kv.Key, kv => kv.Value), options);
+            writer.WritePropertyName(nameof(CharacterStateSnapshot.EquipmentsDetail));
+            JsonSerializer.Serialize(writer, value.EquipmentsDetail, options);
             writer.WritePropertyName(nameof(CharacterStateSnapshot.Skills));
             JsonSerializer.Serialize(writer, value.Skills, options);
             writer.WritePropertyName(nameof(CharacterStateSnapshot.Items));

--- a/Library/Common/JsonConverter/CharacterStateSnapshotConverter.cs
+++ b/Library/Common/JsonConverter/CharacterStateSnapshotConverter.cs
@@ -51,6 +51,9 @@ namespace FunGame.Core.Library.Common.JsonConverter
                 case nameof(CharacterStateSnapshot.Skills):
                     result.Skills.AddRange(JsonService.GetObject<List<SkillStateSnapshot>>(ref reader, options) ?? []);
                     break;
+                case nameof(CharacterStateSnapshot.Items):
+                    result.Items.AddRange(JsonService.GetObject<List<ItemStateSnapshot>>(ref reader, options) ?? []);
+                    break;
                 case nameof(CharacterStateSnapshot.Effects):
                     result.Effects.AddRange(JsonService.GetObject<List<EffectStateSnapshot>>(ref reader, options) ?? []);
                     break;
@@ -77,6 +80,8 @@ namespace FunGame.Core.Library.Common.JsonConverter
             JsonSerializer.Serialize(writer, value.Equipments.ToDictionary(kv => (int)kv.Key, kv => kv.Value), options);
             writer.WritePropertyName(nameof(CharacterStateSnapshot.Skills));
             JsonSerializer.Serialize(writer, value.Skills, options);
+            writer.WritePropertyName(nameof(CharacterStateSnapshot.Items));
+            JsonSerializer.Serialize(writer, value.Items, options);
             writer.WritePropertyName(nameof(CharacterStateSnapshot.Effects));
             JsonSerializer.Serialize(writer, value.Effects, options);
             writer.WriteEndObject();

--- a/Library/Common/JsonConverter/CharacterStateSnapshotConverter.cs
+++ b/Library/Common/JsonConverter/CharacterStateSnapshotConverter.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using FunGame.Core.Api;
+using FunGame.Core.Library.Architecture;
+using FunGame.Core.Library.Constant;
+using FunGame.Core.Model.Framework;
+
+namespace FunGame.Core.Library.Common.JsonConverter
+{
+    public class CharacterStateSnapshotConverter : BaseEntityConverter<CharacterStateSnapshot>
+    {
+        public override CharacterStateSnapshot NewInstance()
+        {
+            return new CharacterStateSnapshot();
+        }
+
+        public override void ReadPropertyName(ref Utf8JsonReader reader, string propertyName, JsonSerializerOptions options, ref CharacterStateSnapshot result, Dictionary<string, object> convertingContext)
+        {
+            switch (propertyName)
+            {
+                case nameof(CharacterStateSnapshot.Character):
+                    result.Character = CharacterRefHelper.Read(ref reader);
+                    break;
+                case nameof(CharacterStateSnapshot.HP):
+                    result.HP = reader.GetDouble();
+                    break;
+                case nameof(CharacterStateSnapshot.MaxHP):
+                    result.MaxHP = reader.GetDouble();
+                    break;
+                case nameof(CharacterStateSnapshot.MP):
+                    result.MP = reader.GetDouble();
+                    break;
+                case nameof(CharacterStateSnapshot.MaxMP):
+                    result.MaxMP = reader.GetDouble();
+                    break;
+                case nameof(CharacterStateSnapshot.EP):
+                    result.EP = reader.GetDouble();
+                    break;
+                case nameof(CharacterStateSnapshot.HR):
+                    result.HR = reader.GetDouble();
+                    break;
+                case nameof(CharacterStateSnapshot.MR):
+                    result.MR = reader.GetDouble();
+                    break;
+                case nameof(CharacterStateSnapshot.Equipments):
+                    Dictionary<int, long> equips = JsonService.GetObject<Dictionary<int, long>>(ref reader, options) ?? [];
+                    foreach (KeyValuePair<int, long> kvp in equips)
+                    {
+                        result.Equipments[(EquipSlotType)kvp.Key] = kvp.Value;
+                    }
+                    break;
+                case nameof(CharacterStateSnapshot.Skills):
+                    result.Skills.AddRange(JsonService.GetObject<List<SkillStateSnapshot>>(ref reader, options) ?? []);
+                    break;
+                case nameof(CharacterStateSnapshot.Effects):
+                    result.Effects.AddRange(JsonService.GetObject<List<EffectStateSnapshot>>(ref reader, options) ?? []);
+                    break;
+
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, CharacterStateSnapshot value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(nameof(CharacterStateSnapshot.Character));
+            CharacterRefHelper.Write(writer, value.Character);
+            writer.WriteNumber(nameof(CharacterStateSnapshot.HP), value.HP);
+            writer.WriteNumber(nameof(CharacterStateSnapshot.MaxHP), value.MaxHP);
+            writer.WriteNumber(nameof(CharacterStateSnapshot.MP), value.MP);
+            writer.WriteNumber(nameof(CharacterStateSnapshot.MaxMP), value.MaxMP);
+            writer.WriteNumber(nameof(CharacterStateSnapshot.EP), value.EP);
+            writer.WriteNumber(nameof(CharacterStateSnapshot.HR), value.HR);
+            writer.WriteNumber(nameof(CharacterStateSnapshot.MR), value.MR);
+            writer.WritePropertyName(nameof(CharacterStateSnapshot.Equipments));
+            JsonSerializer.Serialize(writer, value.Equipments.ToDictionary(kv => (int)kv.Key, kv => kv.Value), options);
+            writer.WritePropertyName(nameof(CharacterStateSnapshot.Skills));
+            JsonSerializer.Serialize(writer, value.Skills, options);
+            writer.WritePropertyName(nameof(CharacterStateSnapshot.Effects));
+            JsonSerializer.Serialize(writer, value.Effects, options);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/Library/Common/JsonConverter/EntityRefHelper.cs
+++ b/Library/Common/JsonConverter/EntityRefHelper.cs
@@ -78,6 +78,53 @@ namespace FunGame.Core.Library.Common.JsonConverter
     }
 
     /// <summary>
+    /// 团队引用（轻量快照）的读写辅助：保留 Id、名称、得分、胜者标记与成员角色引用
+    /// </summary>
+    internal static class TeamRefHelper
+    {
+        public static void Write(Utf8JsonWriter writer, Team? team)
+        {
+            writer.WriteStartObject();
+            writer.WriteString(nameof(Team.Id), team?.Id ?? Guid.Empty);
+            writer.WriteString(nameof(Team.Name), team?.Name ?? "");
+            writer.WriteNumber(nameof(Team.Score), team?.Score ?? 0);
+            writer.WriteBoolean(nameof(Team.IsWinner), team?.IsWinner ?? false);
+            writer.WritePropertyName(nameof(Team.Members));
+            CharacterRefHelper.WriteList(writer, team?.Members ?? []);
+            writer.WriteEndObject();
+        }
+
+        public static Team? Read(ref Utf8JsonReader reader)
+        {
+            using JsonDocument doc = JsonDocument.ParseValue(ref reader);
+            return ReadElement(doc.RootElement);
+        }
+
+        internal static Team? ReadElement(JsonElement root)
+        {
+            Guid id = root.TryGetProperty(nameof(Team.Id), out JsonElement idElement) && idElement.ValueKind == JsonValueKind.String ? idElement.GetGuid() : Guid.Empty;
+            string name = root.TryGetProperty(nameof(Team.Name), out JsonElement nameElement) && nameElement.ValueKind == JsonValueKind.String ? nameElement.GetString() ?? "" : "";
+            Team team = new(name, []) { Id = id };
+            if (root.TryGetProperty(nameof(Team.Score), out JsonElement scoreElement) && scoreElement.ValueKind == JsonValueKind.Number)
+            {
+                team.Score = scoreElement.GetInt32();
+            }
+            if (root.TryGetProperty(nameof(Team.IsWinner), out JsonElement winnerElement) && winnerElement.ValueKind == JsonValueKind.True || winnerElement.ValueKind == JsonValueKind.False)
+            {
+                team.IsWinner = winnerElement.GetBoolean();
+            }
+            if (root.TryGetProperty(nameof(Team.Members), out JsonElement membersElement) && membersElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement element in membersElement.EnumerateArray())
+                {
+                    team.Members.Add(CharacterRefHelper.ReadElement(element));
+                }
+            }
+            return team;
+        }
+    }
+
+    /// <summary>
     /// 技能引用（轻量快照）的读写辅助：只保留 Id 与名称，供展示与消耗匹配
     /// </summary>
     internal static class SkillRefHelper

--- a/Library/Common/JsonConverter/EntityRefHelper.cs
+++ b/Library/Common/JsonConverter/EntityRefHelper.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using FunGame.Core.Entity;
+using FunGame.Core.Library.Constant;
 
 namespace FunGame.Core.Library.Common.JsonConverter
 {
@@ -134,6 +135,7 @@ namespace FunGame.Core.Library.Common.JsonConverter
             writer.WriteStartObject();
             writer.WriteNumber(nameof(Skill.Id), skill?.Id ?? 0);
             writer.WriteString(nameof(Skill.Name), skill?.Name ?? "");
+            writer.WriteNumber(nameof(Skill.SkillType), (int)(skill?.SkillType ?? SkillType.Magic));
             writer.WriteEndObject();
         }
 
@@ -147,7 +149,8 @@ namespace FunGame.Core.Library.Common.JsonConverter
         {
             long id = root.TryGetProperty(nameof(Skill.Id), out JsonElement idElement) && idElement.ValueKind == JsonValueKind.Number ? idElement.GetInt64() : 0;
             string name = root.TryGetProperty(nameof(Skill.Name), out JsonElement nameElement) && nameElement.ValueKind == JsonValueKind.String ? nameElement.GetString() ?? "" : "";
-            return id == 0 && name == "" ? null : new OpenSkill(id, name, []);
+            SkillType skillType = root.TryGetProperty(nameof(Skill.SkillType), out JsonElement stElement) && stElement.ValueKind == JsonValueKind.Number ? (SkillType)stElement.GetInt32() : SkillType.Magic;
+            return id == 0 && name == "" ? null : new OpenSkill(id, name, []) { SkillType = skillType };
         }
     }
 

--- a/Library/Common/JsonConverter/EntityRefHelper.cs
+++ b/Library/Common/JsonConverter/EntityRefHelper.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using FunGame.Core.Entity;
+
+namespace FunGame.Core.Library.Common.JsonConverter
+{
+    /// <summary>
+    /// 角色引用（轻量快照）的读写辅助：只保留展示所需字段，避免在回合记录中序列化完整的角色对象图
+    /// </summary>
+    internal static class CharacterRefHelper
+    {
+        public static void Write(Utf8JsonWriter writer, Character? character)
+        {
+            writer.WriteStartObject();
+            writer.WriteString(nameof(Character.Guid), character?.Guid ?? Guid.Empty);
+            writer.WriteString(nameof(Character.Name), character?.Name ?? "");
+            writer.WriteString(nameof(Character.FirstName), character?.FirstName ?? "");
+            writer.WriteString(nameof(Character.NickName), character?.NickName ?? "");
+            writer.WriteString("UserName", character?.User?.Username ?? "");
+            writer.WriteEndObject();
+        }
+
+        public static Character Read(ref Utf8JsonReader reader)
+        {
+            using JsonDocument doc = JsonDocument.ParseValue(ref reader);
+            return ReadElement(doc.RootElement);
+        }
+
+        public static void WriteList(Utf8JsonWriter writer, IEnumerable<Character> characters)
+        {
+            writer.WriteStartArray();
+            foreach (Character character in characters)
+            {
+                Write(writer, character);
+            }
+            writer.WriteEndArray();
+        }
+
+        public static List<Character> ReadList(ref Utf8JsonReader reader)
+        {
+            List<Character> list = [];
+            using JsonDocument doc = JsonDocument.ParseValue(ref reader);
+            foreach (JsonElement element in doc.RootElement.EnumerateArray())
+            {
+                list.Add(ReadElement(element));
+            }
+            return list;
+        }
+
+        internal static Character ReadElement(JsonElement root)
+        {
+            Character character = new();
+            if (root.TryGetProperty(nameof(Character.Guid), out JsonElement guid) && guid.ValueKind == JsonValueKind.String)
+            {
+                character.Guid = guid.GetGuid();
+            }
+            if (root.TryGetProperty(nameof(Character.Name), out JsonElement name) && name.ValueKind == JsonValueKind.String)
+            {
+                character.Name = name.GetString() ?? "";
+            }
+            if (root.TryGetProperty(nameof(Character.FirstName), out JsonElement firstName) && firstName.ValueKind == JsonValueKind.String)
+            {
+                character.FirstName = firstName.GetString() ?? "";
+            }
+            if (root.TryGetProperty(nameof(Character.NickName), out JsonElement nickName) && nickName.ValueKind == JsonValueKind.String)
+            {
+                character.NickName = nickName.GetString() ?? "";
+            }
+            if (root.TryGetProperty("UserName", out JsonElement userName) && userName.ValueKind == JsonValueKind.String)
+            {
+                string username = userName.GetString() ?? "";
+                if (username != "")
+                {
+                    character.User = new User() { Username = username };
+                }
+            }
+            return character;
+        }
+    }
+
+    /// <summary>
+    /// 技能引用（轻量快照）的读写辅助：只保留 Id 与名称，供展示与消耗匹配
+    /// </summary>
+    internal static class SkillRefHelper
+    {
+        public static void Write(Utf8JsonWriter writer, Skill? skill)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber(nameof(Skill.Id), skill?.Id ?? 0);
+            writer.WriteString(nameof(Skill.Name), skill?.Name ?? "");
+            writer.WriteEndObject();
+        }
+
+        public static Skill? Read(ref Utf8JsonReader reader)
+        {
+            using JsonDocument doc = JsonDocument.ParseValue(ref reader);
+            return ReadElement(doc.RootElement);
+        }
+
+        internal static Skill? ReadElement(JsonElement root)
+        {
+            long id = root.TryGetProperty(nameof(Skill.Id), out JsonElement idElement) && idElement.ValueKind == JsonValueKind.Number ? idElement.GetInt64() : 0;
+            string name = root.TryGetProperty(nameof(Skill.Name), out JsonElement nameElement) && nameElement.ValueKind == JsonValueKind.String ? nameElement.GetString() ?? "" : "";
+            return id == 0 && name == "" ? null : new OpenSkill(id, name, []);
+        }
+    }
+
+    /// <summary>
+    /// 物品引用（轻量快照）的读写辅助：只保留 Id 与名称，供展示与消耗匹配
+    /// </summary>
+    internal static class ItemRefHelper
+    {
+        public static void Write(Utf8JsonWriter writer, Item? item)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber(nameof(Item.Id), item?.Id ?? 0);
+            writer.WriteString(nameof(Item.Name), item?.Name ?? "");
+            writer.WriteEndObject();
+        }
+
+        public static Item? Read(ref Utf8JsonReader reader)
+        {
+            using JsonDocument doc = JsonDocument.ParseValue(ref reader);
+            return ReadElement(doc.RootElement);
+        }
+
+        internal static Item? ReadElement(JsonElement root)
+        {
+            long id = root.TryGetProperty(nameof(Item.Id), out JsonElement idElement) && idElement.ValueKind == JsonValueKind.Number ? idElement.GetInt64() : 0;
+            string name = root.TryGetProperty(nameof(Item.Name), out JsonElement nameElement) && nameElement.ValueKind == JsonValueKind.String ? nameElement.GetString() ?? "" : "";
+            return id == 0 && name == "" ? null : new OpenItem(id, name, []);
+        }
+    }
+}

--- a/Library/Common/JsonConverter/RankingEntryConverter.cs
+++ b/Library/Common/JsonConverter/RankingEntryConverter.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using FunGame.Core.Entity;
+using FunGame.Core.Library.Architecture;
+using FunGame.Core.Model.Framework;
+
+namespace FunGame.Core.Library.Common.JsonConverter
+{
+    public class RankingEntryConverter : BaseEntityConverter<RankingEntry>
+    {
+        public override RankingEntry NewInstance()
+        {
+            return new RankingEntry();
+        }
+
+        public override void ReadPropertyName(ref Utf8JsonReader reader, string propertyName, JsonSerializerOptions options, ref RankingEntry result, Dictionary<string, object> convertingContext)
+        {
+            switch (propertyName)
+            {
+                case nameof(RankingEntry.Rank):
+                    result.Rank = reader.GetInt32();
+                    break;
+                case nameof(RankingEntry.IsWinner):
+                    result.IsWinner = reader.GetBoolean();
+                    break;
+                case nameof(RankingEntry.IsTeam):
+                    result.IsTeam = reader.GetBoolean();
+                    break;
+                case nameof(RankingEntry.Character):
+                    result.Character = CharacterRefHelper.Read(ref reader);
+                    break;
+                case nameof(RankingEntry.Team):
+                    result.Team = TeamRefHelper.Read(ref reader);
+                    break;
+                case nameof(RankingEntry.Kills):
+                    result.Kills = reader.GetInt32();
+                    break;
+                case nameof(RankingEntry.Deaths):
+                    result.Deaths = reader.GetInt32();
+                    break;
+                case nameof(RankingEntry.Assists):
+                    result.Assists = reader.GetInt32();
+                    break;
+                case nameof(RankingEntry.FirstKills):
+                    result.FirstKills = reader.GetInt32();
+                    break;
+                case nameof(RankingEntry.TotalEarnedMoney):
+                    result.TotalEarnedMoney = reader.GetInt32();
+                    break;
+                case nameof(RankingEntry.MaxContinuousKilling):
+                    result.MaxContinuousKilling = reader.GetInt32();
+                    break;
+                case nameof(RankingEntry.Score):
+                    result.Score = reader.GetInt32();
+                    break;
+
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, RankingEntry value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber(nameof(RankingEntry.Rank), value.Rank);
+            writer.WriteBoolean(nameof(RankingEntry.IsWinner), value.IsWinner);
+            writer.WriteBoolean(nameof(RankingEntry.IsTeam), value.IsTeam);
+            writer.WritePropertyName(nameof(RankingEntry.Character));
+            CharacterRefHelper.Write(writer, value.Character);
+            writer.WritePropertyName(nameof(RankingEntry.Team));
+            TeamRefHelper.Write(writer, value.Team);
+            writer.WriteNumber(nameof(RankingEntry.Kills), value.Kills);
+            writer.WriteNumber(nameof(RankingEntry.Deaths), value.Deaths);
+            writer.WriteNumber(nameof(RankingEntry.Assists), value.Assists);
+            writer.WriteNumber(nameof(RankingEntry.FirstKills), value.FirstKills);
+            writer.WriteNumber(nameof(RankingEntry.TotalEarnedMoney), value.TotalEarnedMoney);
+            writer.WriteNumber(nameof(RankingEntry.MaxContinuousKilling), value.MaxContinuousKilling);
+            writer.WriteNumber(nameof(RankingEntry.Score), value.Score);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/Library/Common/JsonConverter/RoundRecordConverter.cs
+++ b/Library/Common/JsonConverter/RoundRecordConverter.cs
@@ -9,6 +9,11 @@ namespace FunGame.Core.Library.Common.JsonConverter
 {
     public class RoundRecordConverter : BaseEntityConverter<RoundRecord>
     {
+        /// <summary>
+        /// 序列化时额外输出的角色引用集合属性名，用于反序列化时恢复以角色为 key 的字典
+        /// </summary>
+        private const string AllCharactersProperty = "AllCharacters";
+
         public override RoundRecord NewInstance()
         {
             return new RoundRecord(0);
@@ -21,6 +26,9 @@ namespace FunGame.Core.Library.Common.JsonConverter
                 case nameof(RoundRecord.Round):
                     result.Round = reader.GetInt32();
                     break;
+                case AllCharactersProperty:
+                    convertingContext[AllCharactersProperty] = JsonService.GetObject<List<Character>>(ref reader, options) ?? new List<Character>();
+                    break;
                 case nameof(RoundRecord.Actor):
                     result.Actor = JsonService.GetObject<Character>(ref reader, options) ?? new();
                     break;
@@ -32,15 +40,7 @@ namespace FunGame.Core.Library.Common.JsonConverter
                     }
                     break;
                 case nameof(RoundRecord.Damages):
-                    Dictionary<Guid, double> damagesGuid = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
-                    foreach (KeyValuePair<Guid, double> kvp in damagesGuid)
-                    {
-                        Character? character = FindCharacterByGuid(kvp.Key, result);
-                        if (character != null)
-                        {
-                            result.Damages[character] = kvp.Value;
-                        }
-                    }
+                    convertingContext[nameof(RoundRecord.Damages)] = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
                     break;
 
                 case nameof(RoundRecord.ActionTypes):
@@ -51,31 +51,55 @@ namespace FunGame.Core.Library.Common.JsonConverter
                     }
                     break;
                 case nameof(RoundRecord.Skills):
-                    Dictionary<CharacterActionType, Skill> skills = JsonService.GetObject<Dictionary<CharacterActionType, Skill>>(ref reader, options) ?? [];
-                    foreach (CharacterActionType type in skills.Keys)
+                    using (JsonDocument doc = JsonDocument.ParseValue(ref reader))
                     {
-                        result.Skills[type] = skills[type];
+                        foreach (JsonProperty property in doc.RootElement.EnumerateObject())
+                        {
+                            CharacterActionType? type = ParseActionTypeKey(property.Name);
+                            if (type != null)
+                            {
+                                Skill? skill = property.Value.Deserialize<Skill>(options);
+                                if (skill != null) result.Skills[type.Value] = skill;
+                            }
+                        }
                     }
                     break;
                 case nameof(RoundRecord.SkillsCost):
-                    Dictionary<Skill, string> skillsCost = JsonService.GetObject<Dictionary<Skill, string>>(ref reader, options) ?? [];
-                    foreach (Skill skill in skillsCost.Keys)
+                    // SkillsCost 的 key 以 Id.Name 字符串写入，这里按 Id.Name 匹配回 Skills 中的技能实例
+                    using (JsonDocument costDoc = JsonDocument.ParseValue(ref reader))
                     {
-                        result.SkillsCost[skill] = skillsCost[skill];
+                        foreach (JsonProperty property in costDoc.RootElement.EnumerateObject())
+                        {
+                            string cost = property.Value.GetString() ?? "";
+                            Skill? skill = result.Skills.Values.FirstOrDefault(s => s.GetIdName() == property.Name);
+                            if (skill != null) result.SkillsCost[skill] = cost;
+                        }
                     }
                     break;
                 case nameof(RoundRecord.Items):
-                    Dictionary<CharacterActionType, Item> items = JsonService.GetObject<Dictionary<CharacterActionType, Item>>(ref reader, options) ?? [];
-                    foreach (CharacterActionType type in items.Keys)
+                    using (JsonDocument itemDoc = JsonDocument.ParseValue(ref reader))
                     {
-                        result.Items[type] = items[type];
+                        foreach (JsonProperty property in itemDoc.RootElement.EnumerateObject())
+                        {
+                            CharacterActionType? type = ParseActionTypeKey(property.Name);
+                            if (type != null)
+                            {
+                                Item? item = property.Value.Deserialize<Item>(options);
+                                if (item != null) result.Items[type.Value] = item;
+                            }
+                        }
                     }
                     break;
                 case nameof(RoundRecord.ItemsCost):
-                    Dictionary<Item, string> itemsCost = JsonService.GetObject<Dictionary<Item, string>>(ref reader, options) ?? [];
-                    foreach (Item item in itemsCost.Keys)
+                    // ItemsCost 的 key 以 Id.Name 字符串写入，这里按 Id.Name 匹配回 Items 中的物品实例
+                    using (JsonDocument itemCostDoc = JsonDocument.ParseValue(ref reader))
                     {
-                        result.ItemsCost[item] = itemsCost[item];
+                        foreach (JsonProperty property in itemCostDoc.RootElement.EnumerateObject())
+                        {
+                            string cost = property.Value.GetString() ?? "";
+                            Item? item = result.Items.Values.FirstOrDefault(i => i.GetIdName() == property.Name);
+                            if (item != null) result.ItemsCost[item] = cost;
+                        }
                     }
                     break;
                 case nameof(RoundRecord.HasKill):
@@ -87,71 +111,23 @@ namespace FunGame.Core.Library.Common.JsonConverter
                     break;
 
                 case nameof(RoundRecord.IsCritical):
-                    Dictionary<Guid, bool> isCriticalGuid = JsonService.GetObject<Dictionary<Guid, bool>>(ref reader, options) ?? [];
-                    foreach (KeyValuePair<Guid, bool> kvp in isCriticalGuid)
-                    {
-                        Character? character = FindCharacterByGuid(kvp.Key, result);
-                        if (character != null)
-                        {
-                            result.IsCritical[character] = kvp.Value;
-                        }
-                    }
+                    convertingContext[nameof(RoundRecord.IsCritical)] = JsonService.GetObject<Dictionary<Guid, bool>>(ref reader, options) ?? [];
                     break;
                 case nameof(RoundRecord.IsEvaded):
-                    Dictionary<Guid, bool> isEvadedGuid = JsonService.GetObject<Dictionary<Guid, bool>>(ref reader, options) ?? [];
-                    foreach (KeyValuePair<Guid, bool> kvp in isEvadedGuid)
-                    {
-                        Character? character = FindCharacterByGuid(kvp.Key, result);
-                        if (character != null)
-                        {
-                            result.IsEvaded[character] = kvp.Value;
-                        }
-                    }
+                    convertingContext[nameof(RoundRecord.IsEvaded)] = JsonService.GetObject<Dictionary<Guid, bool>>(ref reader, options) ?? [];
                     break;
                 case nameof(RoundRecord.IsImmune):
-                    Dictionary<Guid, bool> isImmuneGuid = JsonService.GetObject<Dictionary<Guid, bool>>(ref reader, options) ?? [];
-                    foreach (KeyValuePair<Guid, bool> kvp in isImmuneGuid)
-                    {
-                        Character? character = FindCharacterByGuid(kvp.Key, result);
-                        if (character != null)
-                        {
-                            result.IsImmune[character] = kvp.Value;
-                        }
-                    }
+                    convertingContext[nameof(RoundRecord.IsImmune)] = JsonService.GetObject<Dictionary<Guid, bool>>(ref reader, options) ?? [];
                     break;
                 case nameof(RoundRecord.Heals):
-                    Dictionary<Guid, double> healsGuid = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
-                    foreach (KeyValuePair<Guid, double> kvp in healsGuid)
-                    {
-                        Character? character = FindCharacterByGuid(kvp.Key, result);
-                        if (character != null)
-                        {
-                            result.Heals[character] = kvp.Value;
-                        }
-                    }
+                    convertingContext[nameof(RoundRecord.Heals)] = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
                     break;
                 case nameof(RoundRecord.Effects):
-                    Dictionary<Guid, Skill> effectsGuid = JsonService.GetObject<Dictionary<Guid, Skill>>(ref reader, options) ?? [];
-                    foreach (KeyValuePair<Guid, Skill> kvp in effectsGuid)
-                    {
-                        Character? character = FindCharacterByGuid(kvp.Key, result);
-                        if (character != null)
-                        {
-                            result.Effects[character] = kvp.Value;
-                        }
-                    }
+                    convertingContext[nameof(RoundRecord.Effects)] = JsonService.GetObject<Dictionary<Guid, Skill>>(ref reader, options) ?? [];
                     break;
                 case nameof(RoundRecord.ApplyEffects):
-                    Dictionary<Guid, List<EffectType>> applyEffectsGuid = JsonService.GetObject<Dictionary<Guid, List<EffectType>>>(ref reader, options) ?? [];
                     result.ApplyEffects.Clear();
-                    foreach (KeyValuePair<Guid, List<EffectType>> kvp in applyEffectsGuid)
-                    {
-                        Character? character = FindCharacterByGuid(kvp.Key, result);
-                        if (character != null)
-                        {
-                            result.ApplyEffects[character] = kvp.Value;
-                        }
-                    }
+                    convertingContext[nameof(RoundRecord.ApplyEffects)] = JsonService.GetObject<Dictionary<Guid, List<EffectType>>>(ref reader, options) ?? [];
                     break;
                 case nameof(RoundRecord.ActorContinuousKilling):
                     List<string> actorCK = JsonService.GetObject<List<string>>(ref reader, options) ?? [];
@@ -168,15 +144,7 @@ namespace FunGame.Core.Library.Common.JsonConverter
                     result.HardnessTime = reader.GetDouble();
                     break;
                 case nameof(RoundRecord.RespawnCountdowns):
-                    Dictionary<Guid, double> respawnCountdownGuid = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
-                    foreach (KeyValuePair<Guid, double> kvp in respawnCountdownGuid)
-                    {
-                        Character? character = FindCharacterByGuid(kvp.Key, result);
-                        if (character != null)
-                        {
-                            result.RespawnCountdowns[character] = kvp.Value;
-                        }
-                    }
+                    convertingContext[nameof(RoundRecord.RespawnCountdowns)] = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
                     break;
                 case nameof(RoundRecord.Respawns):
                     List<Character> respawns = JsonService.GetObject<List<Character>>(ref reader, options) ?? [];
@@ -201,6 +169,12 @@ namespace FunGame.Core.Library.Common.JsonConverter
         {
             writer.WriteStartObject();
             writer.WriteNumber(nameof(RoundRecord.Round), value.Round);
+            // 收集所有涉及的角色引用，供反序列化时恢复以角色为 key 的字典（Damages/Heals/Effects/ApplyEffects 等）
+            List<Character> allCharacters = [value.Actor, .. value.Targets.Values.SelectMany(c => c), .. value.Assists, .. value.Respawns];
+            allCharacters.AddRange([.. value.Damages.Keys, .. value.Heals.Keys, .. value.Effects.Keys, .. value.ApplyEffects.Keys, .. value.IsCritical.Keys, .. value.IsEvaded.Keys, .. value.IsImmune.Keys, .. value.RespawnCountdowns.Keys]);
+            allCharacters = [.. allCharacters.Where(c => c != null && c.Guid != Guid.Empty).DistinctBy(c => c.Guid)];
+            writer.WritePropertyName(AllCharactersProperty);
+            JsonSerializer.Serialize(writer, allCharacters, options);
             writer.WritePropertyName(nameof(RoundRecord.Actor));
             JsonSerializer.Serialize(writer, value.Actor, options);
             writer.WritePropertyName(nameof(RoundRecord.Targets));
@@ -210,11 +184,11 @@ namespace FunGame.Core.Library.Common.JsonConverter
             writer.WritePropertyName(nameof(RoundRecord.ActionTypes));
             JsonSerializer.Serialize(writer, value.ActionTypes.Select(type => (int)type), options);
             writer.WritePropertyName(nameof(RoundRecord.Skills));
-            JsonSerializer.Serialize(writer, value.Skills.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value), options);
+            JsonSerializer.Serialize(writer, value.Skills.ToDictionary(kv => (int)kv.Key, kv => kv.Value), options);
             writer.WritePropertyName(nameof(RoundRecord.SkillsCost));
             JsonSerializer.Serialize(writer, value.SkillsCost.ToDictionary(kv => kv.Key.GetIdName(), kv => kv.Value), options);
             writer.WritePropertyName(nameof(RoundRecord.Items));
-            JsonSerializer.Serialize(writer, value.Items.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value), options);
+            JsonSerializer.Serialize(writer, value.Items.ToDictionary(kv => (int)kv.Key, kv => kv.Value), options);
             writer.WritePropertyName(nameof(RoundRecord.ItemsCost));
             JsonSerializer.Serialize(writer, value.ItemsCost.ToDictionary(kv => kv.Key.GetIdName(), kv => kv.Value), options);
             writer.WriteBoolean(nameof(RoundRecord.HasKill), value.HasKill);
@@ -249,15 +223,62 @@ namespace FunGame.Core.Library.Common.JsonConverter
             writer.WriteEndObject();
         }
 
-        private static Character? FindCharacterByGuid(Guid guid, RoundRecord record)
+        public override void AfterConvert(ref RoundRecord result, Dictionary<string, object> convertingContext)
         {
-            Character? character = record.Targets.Values.SelectMany(c => c).FirstOrDefault(c => c.Guid == guid);
-            if (character != null) return character;
+            RoundRecord record = result;
+            List<Character>? allCharacters = convertingContext.TryGetValue(AllCharactersProperty, out object? ac) ? ac as List<Character> : null;
+
+            ResolveCharacterKeyed<double>(record, convertingContext, nameof(RoundRecord.Damages), allCharacters, (c, v) => record.Damages[c] = v);
+            ResolveCharacterKeyed<bool>(record, convertingContext, nameof(RoundRecord.IsCritical), allCharacters, (c, v) => record.IsCritical[c] = v);
+            ResolveCharacterKeyed<bool>(record, convertingContext, nameof(RoundRecord.IsEvaded), allCharacters, (c, v) => record.IsEvaded[c] = v);
+            ResolveCharacterKeyed<bool>(record, convertingContext, nameof(RoundRecord.IsImmune), allCharacters, (c, v) => record.IsImmune[c] = v);
+            ResolveCharacterKeyed<double>(record, convertingContext, nameof(RoundRecord.Heals), allCharacters, (c, v) => record.Heals[c] = v);
+            ResolveCharacterKeyed<Skill>(record, convertingContext, nameof(RoundRecord.Effects), allCharacters, (c, v) => record.Effects[c] = v);
+            ResolveCharacterKeyed<List<EffectType>>(record, convertingContext, nameof(RoundRecord.ApplyEffects), allCharacters, (c, v) => record.ApplyEffects[c] = v);
+            ResolveCharacterKeyed<double>(record, convertingContext, nameof(RoundRecord.RespawnCountdowns), allCharacters, (c, v) => record.RespawnCountdowns[c] = v);
+        }
+
+        /// <summary>
+        /// 将反序列化时暂存的 Guid 键字典解析为以角色引用为 key 的字典
+        /// </summary>
+        private static void ResolveCharacterKeyed<T>(RoundRecord result, Dictionary<string, object> convertingContext, string propertyName, List<Character>? allCharacters, Action<Character, T> set)
+        {
+            if (convertingContext.TryGetValue(propertyName, out object? raw) && raw is Dictionary<Guid, T> dict)
+            {
+                foreach (KeyValuePair<Guid, T> kvp in dict)
+                {
+                    Character? character = FindCharacterByGuid(kvp.Key, result, allCharacters);
+                    if (character != null) set(character, kvp.Value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 解析字典键为 <see cref="CharacterActionType"/>，兼容数字枚举值与字符串枚举名两种写法
+        /// </summary>
+        private static CharacterActionType? ParseActionTypeKey(string key)
+        {
+            if (int.TryParse(key, out int value)) return (CharacterActionType)value;
+            if (Enum.TryParse(key, out CharacterActionType type)) return type;
+            return null;
+        }
+
+        private static Character? FindCharacterByGuid(Guid guid, RoundRecord record, List<Character>? allCharacters)
+        {
+            if (allCharacters != null)
+            {
+                Character? character = allCharacters.FirstOrDefault(c => c.Guid == guid);
+                if (character != null) return character;
+            }
+
+            // 兼容旧存档（无 AllCharacters 字段）：从既有字段中查找
+            Character? fallback = record.Targets.Values.SelectMany(c => c).FirstOrDefault(c => c.Guid == guid);
+            if (fallback != null) return fallback;
             if (record.Actor != null && record.Actor.Guid == guid) return record.Actor;
-            character = record.Assists.FirstOrDefault(c => c.Guid == guid);
-            if (character != null) return character;
-            character = record.Respawns.FirstOrDefault(c => c.Guid == guid);
-            if (character != null) return character;
+            fallback = record.Assists.FirstOrDefault(c => c.Guid == guid);
+            if (fallback != null) return fallback;
+            fallback = record.Respawns.FirstOrDefault(c => c.Guid == guid);
+            if (fallback != null) return fallback;
             return null;
         }
     }

--- a/Library/Common/JsonConverter/RoundRecordConverter.cs
+++ b/Library/Common/JsonConverter/RoundRecordConverter.cs
@@ -27,16 +27,29 @@ namespace FunGame.Core.Library.Common.JsonConverter
                     result.Round = reader.GetInt32();
                     break;
                 case AllCharactersProperty:
-                    convertingContext[AllCharactersProperty] = JsonService.GetObject<List<Character>>(ref reader, options) ?? new List<Character>();
+                    List<Character> allCharacters = CharacterRefHelper.ReadList(ref reader);
+                    result.AllCharacters.AddRange(allCharacters);
+                    convertingContext[AllCharactersProperty] = allCharacters;
                     break;
                 case nameof(RoundRecord.Actor):
-                    result.Actor = JsonService.GetObject<Character>(ref reader, options) ?? new();
+                    result.Actor = CharacterRefHelper.Read(ref reader);
                     break;
                 case nameof(RoundRecord.Targets):
-                    Dictionary<CharacterActionType, List<Character>> targets = JsonService.GetObject<Dictionary<CharacterActionType, List<Character>>>(ref reader, options) ?? [];
-                    foreach (CharacterActionType type in targets.Keys)
+                    using (JsonDocument targetDoc = JsonDocument.ParseValue(ref reader))
                     {
-                        result.Targets[type] = targets[type];
+                        foreach (JsonProperty property in targetDoc.RootElement.EnumerateObject())
+                        {
+                            CharacterActionType? type = ParseActionTypeKey(property.Name);
+                            if (type != null)
+                            {
+                                List<Character> list = [];
+                                foreach (JsonElement element in property.Value.EnumerateArray())
+                                {
+                                    list.Add(CharacterRefHelper.ReadElement(element));
+                                }
+                                result.Targets[type.Value] = list;
+                            }
+                        }
                     }
                     break;
                 case nameof(RoundRecord.Damages):
@@ -58,7 +71,7 @@ namespace FunGame.Core.Library.Common.JsonConverter
                             CharacterActionType? type = ParseActionTypeKey(property.Name);
                             if (type != null)
                             {
-                                Skill? skill = property.Value.Deserialize<Skill>(options);
+                                Skill? skill = SkillRefHelper.ReadElement(property.Value);
                                 if (skill != null) result.Skills[type.Value] = skill;
                             }
                         }
@@ -84,7 +97,7 @@ namespace FunGame.Core.Library.Common.JsonConverter
                             CharacterActionType? type = ParseActionTypeKey(property.Name);
                             if (type != null)
                             {
-                                Item? item = property.Value.Deserialize<Item>(options);
+                                Item? item = ItemRefHelper.ReadElement(property.Value);
                                 if (item != null) result.Items[type.Value] = item;
                             }
                         }
@@ -106,8 +119,7 @@ namespace FunGame.Core.Library.Common.JsonConverter
                     result.HasKill = reader.GetBoolean();
                     break;
                 case nameof(RoundRecord.Assists):
-                    List<Character> assists = JsonService.GetObject<List<Character>>(ref reader, options) ?? [];
-                    result.Assists.AddRange(assists);
+                    result.Assists.AddRange(CharacterRefHelper.ReadList(ref reader));
                     break;
 
                 case nameof(RoundRecord.IsCritical):
@@ -123,7 +135,19 @@ namespace FunGame.Core.Library.Common.JsonConverter
                     convertingContext[nameof(RoundRecord.Heals)] = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
                     break;
                 case nameof(RoundRecord.Effects):
-                    convertingContext[nameof(RoundRecord.Effects)] = JsonService.GetObject<Dictionary<Guid, Skill>>(ref reader, options) ?? [];
+                    Dictionary<Guid, Skill> effects = [];
+                    using (JsonDocument effectDoc = JsonDocument.ParseValue(ref reader))
+                    {
+                        foreach (JsonProperty property in effectDoc.RootElement.EnumerateObject())
+                        {
+                            if (Guid.TryParse(property.Name, out Guid guid))
+                            {
+                                Skill? skill = SkillRefHelper.ReadElement(property.Value);
+                                if (skill != null) effects[guid] = skill;
+                            }
+                        }
+                    }
+                    convertingContext[nameof(RoundRecord.Effects)] = effects;
                     break;
                 case nameof(RoundRecord.ApplyEffects):
                     result.ApplyEffects.Clear();
@@ -147,16 +171,30 @@ namespace FunGame.Core.Library.Common.JsonConverter
                     convertingContext[nameof(RoundRecord.RespawnCountdowns)] = JsonService.GetObject<Dictionary<Guid, double>>(ref reader, options) ?? [];
                     break;
                 case nameof(RoundRecord.Respawns):
-                    List<Character> respawns = JsonService.GetObject<List<Character>>(ref reader, options) ?? [];
-                    result.Respawns.AddRange(respawns);
+                    result.Respawns.AddRange(CharacterRefHelper.ReadList(ref reader));
                     break;
                 case nameof(RoundRecord.RoundRewards):
-                    List<Skill> rewards = JsonService.GetObject<List<Skill>>(ref reader, options) ?? [];
-                    result.RoundRewards.AddRange(rewards);
+                    using (JsonDocument rewardDoc = JsonDocument.ParseValue(ref reader))
+                    {
+                        foreach (JsonElement element in rewardDoc.RootElement.EnumerateArray())
+                        {
+                            Skill? skill = SkillRefHelper.ReadElement(element);
+                            if (skill != null) result.RoundRewards.Add(skill);
+                        }
+                    }
                     break;
                 case nameof(RoundRecord.OtherMessages):
                     List<string> messages = JsonService.GetObject<List<string>>(ref reader, options) ?? [];
                     result.OtherMessages.AddRange(messages);
+                    break;
+                case nameof(RoundRecord.Actions):
+                    result.Actions.AddRange(JsonService.GetObject<List<ActionRecord>>(ref reader, options) ?? []);
+                    break;
+                case nameof(RoundRecord.Checkpoint):
+                    result.Checkpoint = JsonService.GetObject<List<CharacterStateSnapshot>>(ref reader, options);
+                    break;
+                case nameof(RoundRecord.TotalTime):
+                    result.TotalTime = reader.GetDouble();
                     break;
 
                 default:
@@ -169,31 +207,57 @@ namespace FunGame.Core.Library.Common.JsonConverter
         {
             writer.WriteStartObject();
             writer.WriteNumber(nameof(RoundRecord.Round), value.Round);
-            // 收集所有涉及的角色引用，供反序列化时恢复以角色为 key 的字典（Damages/Heals/Effects/ApplyEffects 等）
-            List<Character> allCharacters = [value.Actor, .. value.Targets.Values.SelectMany(c => c), .. value.Assists, .. value.Respawns];
-            allCharacters.AddRange([.. value.Damages.Keys, .. value.Heals.Keys, .. value.Effects.Keys, .. value.ApplyEffects.Keys, .. value.IsCritical.Keys, .. value.IsEvaded.Keys, .. value.IsImmune.Keys, .. value.RespawnCountdowns.Keys]);
-            allCharacters = [.. allCharacters.Where(c => c != null && c.Guid != Guid.Empty).DistinctBy(c => c.Guid)];
+            // 收集角色引用：优先使用显式设置的全角色清单（开局时写入），否则动态收集本回合出现的角色
+            List<Character> allCharacters;
+            if (value.AllCharacters.Count > 0)
+            {
+                allCharacters = [.. value.AllCharacters.Where(c => c != null && c.Guid != Guid.Empty).DistinctBy(c => c.Guid)];
+            }
+            else
+            {
+                allCharacters = [value.Actor, .. value.Targets.Values.SelectMany(c => c), .. value.Assists, .. value.Respawns];
+                allCharacters.AddRange([.. value.Damages.Keys, .. value.Heals.Keys, .. value.Effects.Keys, .. value.ApplyEffects.Keys, .. value.IsCritical.Keys, .. value.IsEvaded.Keys, .. value.IsImmune.Keys, .. value.RespawnCountdowns.Keys]);
+                allCharacters = [.. allCharacters.Where(c => c != null && c.Guid != Guid.Empty).DistinctBy(c => c.Guid)];
+            }
             writer.WritePropertyName(AllCharactersProperty);
-            JsonSerializer.Serialize(writer, allCharacters, options);
+            CharacterRefHelper.WriteList(writer, allCharacters);
             writer.WritePropertyName(nameof(RoundRecord.Actor));
-            JsonSerializer.Serialize(writer, value.Actor, options);
+            CharacterRefHelper.Write(writer, value.Actor);
             writer.WritePropertyName(nameof(RoundRecord.Targets));
-            JsonSerializer.Serialize(writer, value.Targets, options);
+            writer.WriteStartObject();
+            foreach (KeyValuePair<CharacterActionType, List<Character>> kv in value.Targets)
+            {
+                writer.WritePropertyName(((int)kv.Key).ToString());
+                CharacterRefHelper.WriteList(writer, kv.Value);
+            }
+            writer.WriteEndObject();
             writer.WritePropertyName(nameof(RoundRecord.Damages));
             JsonSerializer.Serialize(writer, value.Damages.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
             writer.WritePropertyName(nameof(RoundRecord.ActionTypes));
             JsonSerializer.Serialize(writer, value.ActionTypes.Select(type => (int)type), options);
             writer.WritePropertyName(nameof(RoundRecord.Skills));
-            JsonSerializer.Serialize(writer, value.Skills.ToDictionary(kv => (int)kv.Key, kv => kv.Value), options);
+            writer.WriteStartObject();
+            foreach (KeyValuePair<CharacterActionType, Skill> kv in value.Skills)
+            {
+                writer.WritePropertyName(((int)kv.Key).ToString());
+                SkillRefHelper.Write(writer, kv.Value);
+            }
+            writer.WriteEndObject();
             writer.WritePropertyName(nameof(RoundRecord.SkillsCost));
             JsonSerializer.Serialize(writer, value.SkillsCost.ToDictionary(kv => kv.Key.GetIdName(), kv => kv.Value), options);
             writer.WritePropertyName(nameof(RoundRecord.Items));
-            JsonSerializer.Serialize(writer, value.Items.ToDictionary(kv => (int)kv.Key, kv => kv.Value), options);
+            writer.WriteStartObject();
+            foreach (KeyValuePair<CharacterActionType, Item> kv in value.Items)
+            {
+                writer.WritePropertyName(((int)kv.Key).ToString());
+                ItemRefHelper.Write(writer, kv.Value);
+            }
+            writer.WriteEndObject();
             writer.WritePropertyName(nameof(RoundRecord.ItemsCost));
             JsonSerializer.Serialize(writer, value.ItemsCost.ToDictionary(kv => kv.Key.GetIdName(), kv => kv.Value), options);
             writer.WriteBoolean(nameof(RoundRecord.HasKill), value.HasKill);
             writer.WritePropertyName(nameof(RoundRecord.Assists));
-            JsonSerializer.Serialize(writer, value.Assists, options);
+            CharacterRefHelper.WriteList(writer, value.Assists);
             writer.WritePropertyName(nameof(RoundRecord.IsCritical));
             JsonSerializer.Serialize(writer, value.IsCritical.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
             writer.WritePropertyName(nameof(RoundRecord.IsEvaded));
@@ -203,7 +267,13 @@ namespace FunGame.Core.Library.Common.JsonConverter
             writer.WritePropertyName(nameof(RoundRecord.Heals));
             JsonSerializer.Serialize(writer, value.Heals.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
             writer.WritePropertyName(nameof(RoundRecord.Effects));
-            JsonSerializer.Serialize(writer, value.Effects.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
+            writer.WriteStartObject();
+            foreach (KeyValuePair<Character, Skill> kv in value.Effects)
+            {
+                writer.WritePropertyName(kv.Key.Guid.ToString());
+                SkillRefHelper.Write(writer, kv.Value);
+            }
+            writer.WriteEndObject();
             writer.WritePropertyName(nameof(RoundRecord.ApplyEffects));
             JsonSerializer.Serialize(writer, value.ApplyEffects.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
             writer.WritePropertyName(nameof(RoundRecord.ActorContinuousKilling));
@@ -215,11 +285,28 @@ namespace FunGame.Core.Library.Common.JsonConverter
             writer.WritePropertyName(nameof(RoundRecord.RespawnCountdowns));
             JsonSerializer.Serialize(writer, value.RespawnCountdowns.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
             writer.WritePropertyName(nameof(RoundRecord.Respawns));
-            JsonSerializer.Serialize(writer, value.Respawns, options);
+            CharacterRefHelper.WriteList(writer, value.Respawns);
             writer.WritePropertyName(nameof(RoundRecord.RoundRewards));
-            JsonSerializer.Serialize(writer, value.RoundRewards, options);
+            writer.WriteStartArray();
+            foreach (Skill skill in value.RoundRewards)
+            {
+                SkillRefHelper.Write(writer, skill);
+            }
+            writer.WriteEndArray();
             writer.WritePropertyName(nameof(RoundRecord.OtherMessages));
             JsonSerializer.Serialize(writer, value.OtherMessages, options);
+            writer.WritePropertyName(nameof(RoundRecord.Actions));
+            JsonSerializer.Serialize(writer, value.Actions, options);
+            writer.WritePropertyName(nameof(RoundRecord.Checkpoint));
+            if (value.Checkpoint != null)
+            {
+                JsonSerializer.Serialize(writer, value.Checkpoint, options);
+            }
+            else
+            {
+                writer.WriteNullValue();
+            }
+            writer.WriteNumber(nameof(RoundRecord.TotalTime), value.TotalTime);
             writer.WriteEndObject();
         }
 

--- a/Library/Common/JsonConverter/RoundRecordConverter.cs
+++ b/Library/Common/JsonConverter/RoundRecordConverter.cs
@@ -200,7 +200,10 @@ namespace FunGame.Core.Library.Common.JsonConverter
                     result.GameResult.AddRange(JsonService.GetObject<List<RankingEntry>>(ref reader, options) ?? []);
                     break;
                 case nameof(RoundRecord.TeamMap):
-                    result.TeamMap = JsonService.GetObject<Dictionary<Guid, string>>(ref reader, options) ?? new Dictionary<Guid, string>();
+                    result.TeamMap = JsonService.GetObject<Dictionary<Guid, string>>(ref reader, options) ?? [];
+                    break;
+                case nameof(RoundRecord.CharacterStatistics):
+                    convertingContext[nameof(RoundRecord.CharacterStatistics)] = JsonService.GetObject<Dictionary<Guid, CharacterStatistics>>(ref reader, options) ?? [];
                     break;
 
                 default:
@@ -317,6 +320,8 @@ namespace FunGame.Core.Library.Common.JsonConverter
             JsonSerializer.Serialize(writer, value.GameResult, options);
             writer.WritePropertyName(nameof(RoundRecord.TeamMap));
             JsonSerializer.Serialize(writer, value.TeamMap, options);
+            writer.WritePropertyName(nameof(RoundRecord.CharacterStatistics));
+            JsonSerializer.Serialize(writer, value.CharacterStatistics.ToDictionary(kv => kv.Key.Guid, kv => kv.Value), options);
             writer.WriteEndObject();
         }
 
@@ -333,6 +338,7 @@ namespace FunGame.Core.Library.Common.JsonConverter
             ResolveCharacterKeyed<Skill>(record, convertingContext, nameof(RoundRecord.Effects), allCharacters, (c, v) => record.Effects[c] = v);
             ResolveCharacterKeyed<List<EffectType>>(record, convertingContext, nameof(RoundRecord.ApplyEffects), allCharacters, (c, v) => record.ApplyEffects[c] = v);
             ResolveCharacterKeyed<double>(record, convertingContext, nameof(RoundRecord.RespawnCountdowns), allCharacters, (c, v) => record.RespawnCountdowns[c] = v);
+            ResolveCharacterKeyed<CharacterStatistics>(record, convertingContext, nameof(RoundRecord.CharacterStatistics), allCharacters, (c, v) => record.CharacterStatistics[c] = v);
         }
 
         /// <summary>

--- a/Library/Common/JsonConverter/RoundRecordConverter.cs
+++ b/Library/Common/JsonConverter/RoundRecordConverter.cs
@@ -196,6 +196,12 @@ namespace FunGame.Core.Library.Common.JsonConverter
                 case nameof(RoundRecord.TotalTime):
                     result.TotalTime = reader.GetDouble();
                     break;
+                case nameof(RoundRecord.GameResult):
+                    result.GameResult.AddRange(JsonService.GetObject<List<RankingEntry>>(ref reader, options) ?? []);
+                    break;
+                case nameof(RoundRecord.TeamMap):
+                    result.TeamMap = JsonService.GetObject<Dictionary<Guid, string>>(ref reader, options) ?? new Dictionary<Guid, string>();
+                    break;
 
                 default:
                     reader.Skip();
@@ -307,6 +313,10 @@ namespace FunGame.Core.Library.Common.JsonConverter
                 writer.WriteNullValue();
             }
             writer.WriteNumber(nameof(RoundRecord.TotalTime), value.TotalTime);
+            writer.WritePropertyName(nameof(RoundRecord.GameResult));
+            JsonSerializer.Serialize(writer, value.GameResult, options);
+            writer.WritePropertyName(nameof(RoundRecord.TeamMap));
+            JsonSerializer.Serialize(writer, value.TeamMap, options);
             writer.WriteEndObject();
         }
 

--- a/Model/Framework/ActionRecord.cs
+++ b/Model/Framework/ActionRecord.cs
@@ -1,0 +1,307 @@
+using System.Text;
+using FunGame.Core.Entity;
+using FunGame.Core.Library.Constant;
+
+namespace FunGame.Core.Model.Framework
+{
+    /// <summary>
+    /// 操作记录：回合内的一次行动<para/>
+    /// 由于决策点系统的存在，一个回合允许执行多次操作，每次操作对应一条 <see cref="ActionRecord"/>；
+    /// 与回合级聚合的 <see cref="RoundRecord"/> 不同，本类按单次操作细致记录其行动类型、技能/物品、目标及每个目标的结果明细。
+    /// </summary>
+    /// <param name="round">归属的回合号</param>
+    public class ActionRecord(int round)
+    {
+        /// <summary>
+        /// 归属的回合号
+        /// </summary>
+        public int Round { get; set; } = round;
+
+        /// <summary>
+        /// 执行操作的角色
+        /// </summary>
+        public Character Actor { get; set; } = new();
+
+        /// <summary>
+        /// 本回合内操作的次序（从 1 开始）
+        /// </summary>
+        public int ActionIndex { get; set; } = 0;
+
+        /// <summary>
+        /// 操作类型（普通攻击/技能/爆发技/使用物品/移动/放弃行动/结束回合等）
+        /// </summary>
+        public CharacterActionType ActionType { get; set; } = CharacterActionType.None;
+
+        /// <summary>
+        /// 操作使用的技能（释放技能/爆发技时为非 null）
+        /// </summary>
+        public Skill? Skill { get; set; } = null;
+
+        /// <summary>
+        /// 操作使用的物品（使用物品时为非 null）
+        /// </summary>
+        public Item? Item { get; set; } = null;
+
+        /// <summary>
+        /// 消耗文本（如 "-30 MP" / "-20 EP" / "-1 使用次数"）
+        /// </summary>
+        public string Cost { get; set; } = "";
+
+        /// <summary>
+        /// 本次操作消耗的魔法值（结构化数值，供状态推算）
+        /// </summary>
+        public double MPCost { get; set; } = 0;
+
+        /// <summary>
+        /// 本次操作消耗的能量值（结构化数值，供状态推算）
+        /// </summary>
+        public double EPCost { get; set; } = 0;
+
+        /// <summary>
+        /// 本次操作释放技能的冷却时长（释放时的 <see cref="Skill.RealCD"/>，供状态推算）
+        /// </summary>
+        public double SkillCD { get; set; } = 0;
+
+        /// <summary>
+        /// 本次操作消耗的决策点
+        /// </summary>
+        public double DecisionPointsCost { get; set; } = 0;
+
+        /// <summary>
+        /// 本次操作的目标列表
+        /// </summary>
+        public List<Character> Targets { get; } = [];
+
+        /// <summary>
+        /// 每个目标受到的伤害值
+        /// </summary>
+        public Dictionary<Character, double> Damages { get; } = [];
+
+        /// <summary>
+        /// 每个目标是否暴击
+        /// </summary>
+        public Dictionary<Character, bool> IsCritical { get; } = [];
+
+        /// <summary>
+        /// 每个目标是否闪避（或技能豁免）
+        /// </summary>
+        public Dictionary<Character, bool> IsEvaded { get; } = [];
+
+        /// <summary>
+        /// 每个目标是否免疫
+        /// </summary>
+        public Dictionary<Character, bool> IsImmune { get; } = [];
+
+        /// <summary>
+        /// 每个目标受到的治疗量
+        /// </summary>
+        public Dictionary<Character, double> Heals { get; } = [];
+
+        /// <summary>
+        /// 对每个目标施加的特效类型
+        /// </summary>
+        public Dictionary<Character, List<EffectType>> ApplyEffects { get; } = [];
+
+        /// <summary>
+        /// 本次操作附带的文本消息（含失败原因等）
+        /// </summary>
+        public List<string> Messages { get; } = [];
+
+        /// <summary>
+        /// 操作是否成功执行（决策点不足/配额超限等失败时为 false）
+        /// </summary>
+        public bool IsSuccess { get; set; } = true;
+
+        /// <summary>
+        /// 失败原因（<see cref="IsSuccess"/> 为 false 时填写）
+        /// </summary>
+        public string FailReason { get; set; } = "";
+
+        /// <summary>
+        /// 吟唱持续时间（吟唱操作为非 0）
+        /// </summary>
+        public double CastTime { get; set; } = 0;
+
+        /// <summary>
+        /// 本操作产生的硬直时间
+        /// </summary>
+        public double HardnessTime { get; set; } = 0;
+
+        /// <summary>
+        /// 记录对 <paramref name="character"/> 施加的特效类型
+        /// </summary>
+        /// <param name="character">被施加特效的角色</param>
+        /// <param name="types">特效类型列表</param>
+        public void AddApplyEffects(Character character, params IEnumerable<EffectType> types)
+        {
+            if (ApplyEffects.TryGetValue(character, out List<EffectType>? list) && list != null)
+            {
+                list.AddRange(types);
+            }
+            else
+            {
+                ApplyEffects.TryAdd(character, [.. types]);
+            }
+        }
+
+        /// <summary>
+        /// 渲染本操作的文本描述（与 <see cref="RoundRecord.ToString()"/> 中的行动段落格式一致）
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            if (!IsSuccess)
+            {
+                return FailReason != "" ? FailReason : $"[ {Actor} ] 操作失败！";
+            }
+
+            StringBuilder builder = new();
+            if (ActionType == CharacterActionType.NormalAttack)
+            {
+                builder.Append($"[ {Actor} ] {Actor.NormalAttack.Name} -> ");
+            }
+            else if (ActionType is CharacterActionType.CastSkill or CharacterActionType.CastSuperSkill or CharacterActionType.PreCastSkill)
+            {
+                string skillName = Skill?.Name ?? "技能";
+                string skillCost = Cost != "" ? $"（{Cost}）" : "";
+                builder.Append($"[ {Actor} ] {skillName}{skillCost} -> ");
+            }
+            else if (ActionType == CharacterActionType.UseItem)
+            {
+                string itemName = Item?.Name ?? "物品";
+                string itemCost = Cost != "" ? $"（{Cost}）" : "";
+                builder.Append($"[ {Actor} ] {itemName}{itemCost} -> ");
+            }
+            else if (ActionType == CharacterActionType.Move)
+            {
+                builder.Append($"[ {Actor} ] 移动 -> ");
+            }
+            else if (ActionType == CharacterActionType.EndTurn)
+            {
+                builder.Append($"[ {Actor} ] 结束回合 -> ");
+            }
+            else
+            {
+                builder.Append($"[ {Actor} ] 行动 -> ");
+            }
+
+            if (Targets.Count > 0)
+            {
+                builder.Append(string.Join(" / ", GetTargetsState()));
+            }
+
+            if (Messages.Count > 0)
+            {
+                builder.AppendLine();
+                builder.Append(string.Join("\r\n", Messages));
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// 生成当前操作的结构快照<para/>
+        /// 所有集合与字典均为独立副本，但其中的实体引用（<see cref="Character"/> / <see cref="Skill"/> / <see cref="Item"/>）与当前记录共享
+        /// </summary>
+        /// <returns></returns>
+        public ActionRecord Snapshot()
+        {
+            ActionRecord snapshot = new(Round)
+            {
+                Actor = Actor,
+                ActionIndex = ActionIndex,
+                ActionType = ActionType,
+                Skill = Skill,
+                Item = Item,
+                Cost = Cost,
+                MPCost = MPCost,
+                EPCost = EPCost,
+                SkillCD = SkillCD,
+                DecisionPointsCost = DecisionPointsCost,
+                IsSuccess = IsSuccess,
+                FailReason = FailReason,
+                CastTime = CastTime,
+                HardnessTime = HardnessTime
+            };
+            snapshot.Targets.AddRange(Targets);
+            foreach (KeyValuePair<Character, double> kv in Damages)
+            {
+                snapshot.Damages[kv.Key] = kv.Value;
+            }
+            foreach (KeyValuePair<Character, bool> kv in IsCritical)
+            {
+                snapshot.IsCritical[kv.Key] = kv.Value;
+            }
+            foreach (KeyValuePair<Character, bool> kv in IsEvaded)
+            {
+                snapshot.IsEvaded[kv.Key] = kv.Value;
+            }
+            foreach (KeyValuePair<Character, bool> kv in IsImmune)
+            {
+                snapshot.IsImmune[kv.Key] = kv.Value;
+            }
+            foreach (KeyValuePair<Character, double> kv in Heals)
+            {
+                snapshot.Heals[kv.Key] = kv.Value;
+            }
+            foreach (KeyValuePair<Character, List<EffectType>> kv in ApplyEffects)
+            {
+                snapshot.ApplyEffects[kv.Key] = [.. kv.Value];
+            }
+            snapshot.Messages.AddRange(Messages);
+            return snapshot;
+        }
+
+        /// <summary>
+        /// 渲染每个目标的状态明细
+        /// </summary>
+        /// <returns></returns>
+        private List<string> GetTargetsState()
+        {
+            List<string> strings = [];
+            foreach (Character target in Targets.Distinct())
+            {
+                string hasDamage = "";
+                string hasHeal = "";
+                string hasEffect = "";
+                string hasEvaded = "";
+                if (Damages.TryGetValue(target, out double damage))
+                {
+                    hasDamage = $"伤害：{damage:0.##}";
+                    if (IsCritical.TryGetValue(target, out bool isCritical) && isCritical)
+                    {
+                        hasDamage = "暴击，" + hasDamage;
+                    }
+                }
+                if (Heals.TryGetValue(target, out double heals))
+                {
+                    hasHeal = $"治疗：{heals:0.##}";
+                }
+                if (ApplyEffects.TryGetValue(target, out List<EffectType>? effectTypes) && effectTypes != null)
+                {
+                    hasEffect = $"施加：{string.Join(" + ", effectTypes.Select(SkillSet.GetEffectTypeName))}";
+                }
+                if (IsEvaded.TryGetValue(target, out bool isEvaded) && isEvaded)
+                {
+                    if (ActionType == CharacterActionType.NormalAttack)
+                    {
+                        hasEvaded = hasDamage == "" ? "完美闪避" : "闪避";
+                    }
+                    else if (ActionType is CharacterActionType.PreCastSkill or CharacterActionType.CastSkill or CharacterActionType.CastSuperSkill)
+                    {
+                        hasEvaded = "技能免疫";
+                    }
+                }
+                if (IsImmune.TryGetValue(target, out bool isImmune) && isImmune && target.Guid != Actor.Guid)
+                {
+                    hasDamage = "免疫";
+                }
+                string[] strs = [hasDamage, hasHeal, hasEffect, hasEvaded];
+                strs = [.. strs.Where(s => s != "")];
+                if (strs.Length == 0) strings.Add($"[ {target} ]");
+                else strings.Add($"[ {target}（{string.Join(" / ", strs)}）]");
+            }
+            return strings;
+        }
+    }
+}

--- a/Model/Framework/CharacterStateSnapshot.cs
+++ b/Model/Framework/CharacterStateSnapshot.cs
@@ -1,0 +1,124 @@
+using FunGame.Core.Entity;
+using FunGame.Core.Library.Constant;
+
+namespace FunGame.Core.Model.Framework
+{
+    /// <summary>
+    /// 角色状态快照（状态检查点中的单个角色状态）<para/>
+    /// 定期检查点 + 事件流推算：作为精确基准，检查点之间的状态由事件流沿时间轴推算
+    /// </summary>
+    public class CharacterStateSnapshot
+    {
+        /// <summary>
+        /// 角色引用（轻量快照）
+        /// </summary>
+        public Character Character { get; set; } = new();
+
+        /// <summary>
+        /// 当前生命值
+        /// </summary>
+        public double HP { get; set; } = 0;
+
+        /// <summary>
+        /// 最大生命值
+        /// </summary>
+        public double MaxHP { get; set; } = 0;
+
+        /// <summary>
+        /// 当前魔法值
+        /// </summary>
+        public double MP { get; set; } = 0;
+
+        /// <summary>
+        /// 最大魔法值
+        /// </summary>
+        public double MaxMP { get; set; } = 0;
+
+        /// <summary>
+        /// 当前能量值
+        /// </summary>
+        public double EP { get; set; } = 0;
+
+        /// <summary>
+        /// 生命回复速率（随时间流逝回复，用于状态推算）
+        /// </summary>
+        public double HR { get; set; } = 0;
+
+        /// <summary>
+        /// 魔法回复速率（随时间流逝回复，用于状态推算）
+        /// </summary>
+        public double MR { get; set; } = 0;
+
+        /// <summary>
+        /// 当前装备栏：装备槽位 -> 物品 ID
+        /// </summary>
+        public Dictionary<EquipSlotType, long> Equipments { get; set; } = [];
+
+        /// <summary>
+        /// 技能状态列表（技能 ID、名称、等级、当前冷却）
+        /// </summary>
+        public List<SkillStateSnapshot> Skills { get; } = [];
+
+        /// <summary>
+        /// 状态栏特效列表（特效 ID、名称、类型、剩余时间）
+        /// </summary>
+        public List<EffectStateSnapshot> Effects { get; } = [];
+    }
+
+    /// <summary>
+    /// 技能状态快照
+    /// </summary>
+    public class SkillStateSnapshot
+    {
+        /// <summary>
+        /// 技能 ID
+        /// </summary>
+        public long SkillId { get; set; } = 0;
+
+        /// <summary>
+        /// 技能名称（展示用）
+        /// </summary>
+        public string SkillName { get; set; } = "";
+
+        /// <summary>
+        /// 技能等级
+        /// </summary>
+        public int Level { get; set; } = 0;
+
+        /// <summary>
+        /// 当前冷却时间
+        /// </summary>
+        public double CurrentCD { get; set; } = 0;
+    }
+
+    /// <summary>
+    /// 状态栏特效快照
+    /// </summary>
+    public class EffectStateSnapshot
+    {
+        /// <summary>
+        /// 特效 ID
+        /// </summary>
+        public long EffectId { get; set; } = 0;
+
+        /// <summary>
+        /// 特效名称（展示用）
+        /// </summary>
+        public string EffectName { get; set; } = "";
+
+        /// <summary>
+        /// 特效类型
+        /// </summary>
+        public EffectType EffectType { get; set; } = EffectType.None;
+
+        /// <summary>
+        /// 剩余持续时间
+        /// </summary>
+        public double RemainDuration { get; set; } = 0;
+
+        /// <summary>
+        /// 剩余持续回合数
+        /// </summary>
+        public int RemainDurationTurn { get; set; } = 0;
+    }
+}

--- a/Model/Framework/CharacterStateSnapshot.cs
+++ b/Model/Framework/CharacterStateSnapshot.cs
@@ -55,6 +55,11 @@ namespace FunGame.Core.Model.Framework
         public Dictionary<EquipSlotType, long> Equipments { get; set; } = [];
 
         /// <summary>
+        /// 装备栏明细（槽位 + 物品 ID + 物品名字，用于展示；序列化后名字可直接使用）
+        /// </summary>
+        public List<EquipmentStateSnapshot> EquipmentsDetail { get; set; } = [];
+
+        /// <summary>
         /// 技能状态列表（技能 ID、名称、等级、当前冷却）
         /// </summary>
         public List<SkillStateSnapshot> Skills { get; } = [];

--- a/Model/Framework/CharacterStateSnapshot.cs
+++ b/Model/Framework/CharacterStateSnapshot.cs
@@ -60,6 +60,11 @@ namespace FunGame.Core.Model.Framework
         public List<SkillStateSnapshot> Skills { get; } = [];
 
         /// <summary>
+        /// 物品栏（背包）列表（物品 ID、名称）
+        /// </summary>
+        public List<ItemStateSnapshot> Items { get; } = [];
+
+        /// <summary>
         /// 状态栏特效列表（特效 ID、名称、类型、剩余时间）
         /// </summary>
         public List<EffectStateSnapshot> Effects { get; } = [];
@@ -89,6 +94,22 @@ namespace FunGame.Core.Model.Framework
         /// 当前冷却时间
         /// </summary>
         public double CurrentCD { get; set; } = 0;
+    }
+
+    /// <summary>
+    /// 物品状态快照
+    /// </summary>
+    public class ItemStateSnapshot
+    {
+        /// <summary>
+        /// 物品 ID
+        /// </summary>
+        public long ItemId { get; set; } = 0;
+
+        /// <summary>
+        /// 物品名称（展示用）
+        /// </summary>
+        public string ItemName { get; set; } = "";
     }
 
     /// <summary>

--- a/Model/Framework/EquipmentStateSnapshot.cs
+++ b/Model/Framework/EquipmentStateSnapshot.cs
@@ -1,0 +1,25 @@
+using FunGame.Core.Library.Constant;
+
+namespace FunGame.Core.Model.Framework
+{
+    /// <summary>
+    /// 装备栏状态快照（槽位 + 物品 ID + 物品名字，用于回放/展示时显示装备名）
+    /// </summary>
+    public class EquipmentStateSnapshot
+    {
+        /// <summary>
+        /// 装备槽位
+        /// </summary>
+        public EquipSlotType Slot { get; set; }
+
+        /// <summary>
+        /// 物品 ID
+        /// </summary>
+        public long ItemId { get; set; }
+
+        /// <summary>
+        /// 物品名字
+        /// </summary>
+        public string ItemName { get; set; } = "";
+    }
+}

--- a/Model/Framework/RankingEntry.cs
+++ b/Model/Framework/RankingEntry.cs
@@ -1,0 +1,71 @@
+using FunGame.Core.Entity;
+
+namespace FunGame.Core.Model.Framework
+{
+    /// <summary>
+    /// 排名条目（游戏结束时的胜者与排名信息，按名次顺序排列）<para/>
+    /// 使用结构化引用（<see cref="Character"/> / <see cref="Team"/>）与统计数值，消费端可基于引用定制渲染
+    /// </summary>
+    public class RankingEntry
+    {
+        /// <summary>
+        /// 名次（1 = 冠军/胜者）
+        /// </summary>
+        public int Rank { get; set; } = 0;
+
+        /// <summary>
+        /// 是否为胜者
+        /// </summary>
+        public bool IsWinner { get; set; } = false;
+
+        /// <summary>
+        /// 是否为团队条目（true 时使用 <see cref="Team"/>，false 时使用 <see cref="Character"/>）
+        /// </summary>
+        public bool IsTeam { get; set; } = false;
+
+        /// <summary>
+        /// 角色引用（角色排名条目）
+        /// </summary>
+        public Character? Character { get; set; } = null;
+
+        /// <summary>
+        /// 团队引用（团队排名条目）
+        /// </summary>
+        public Team? Team { get; set; } = null;
+
+        /// <summary>
+        /// 击杀数
+        /// </summary>
+        public int Kills { get; set; } = 0;
+
+        /// <summary>
+        /// 死亡数
+        /// </summary>
+        public int Deaths { get; set; } = 0;
+
+        /// <summary>
+        /// 助攻数
+        /// </summary>
+        public int Assists { get; set; } = 0;
+
+        /// <summary>
+        /// 第一滴血数
+        /// </summary>
+        public int FirstKills { get; set; } = 0;
+
+        /// <summary>
+        /// 累计赚取金币
+        /// </summary>
+        public int TotalEarnedMoney { get; set; } = 0;
+
+        /// <summary>
+        /// 最大连杀数
+        /// </summary>
+        public int MaxContinuousKilling { get; set; } = 0;
+
+        /// <summary>
+        /// 团队得分（团队条目）
+        /// </summary>
+        public int Score { get; set; } = 0;
+    }
+}

--- a/Model/Framework/RoundRecord.cs
+++ b/Model/Framework/RoundRecord.cs
@@ -173,8 +173,9 @@ namespace FunGame.Core.Model.Framework
         }
 
         /// <summary>
-        /// 深拷贝当前记录的不可变快照<para/>
-        /// 用于事件分发,保证订阅端看到的是事件时刻的回合状态,而不是后续被修改的引用
+        /// 生成当前记录的结构快照<para/>
+        /// 所有集合与字典均为独立副本，但其中的实体引用（<see cref="Character"/> / <see cref="Skill"/> / <see cref="Item"/>）与当前记录共享；<para/>
+        /// 用于事件分发与回合归档，保证订阅端看到的是快照时刻的回合状态，不受后续对集合结构的修改（新增、覆盖、删除条目）影响
         /// </summary>
         /// <returns></returns>
         public RoundRecord Snapshot()

--- a/Model/Framework/RoundRecord.cs
+++ b/Model/Framework/RoundRecord.cs
@@ -158,8 +158,8 @@ namespace FunGame.Core.Model.Framework
                         if (state.EquipmentsDetail.Count > 0) details.Add("装备: " + string.Join(" / ", state.EquipmentsDetail.Select(e => $"{ItemSet.GetEquipSlotTypeName(e.Slot)}={e.ItemName}")));
                         else if (state.Equipments.Count > 0) details.Add("装备: " + string.Join(" / ", state.Equipments.Select(e => $"{ItemSet.GetEquipSlotTypeName(e.Key)}={e.Value}")));
                         if (state.Items.Count > 0) details.Add("物品: " + string.Join(" / ", state.Items.Select(i => i.ItemName)));
-                        if (state.Skills.Count > 0) details.Add("技能: " + string.Join(" / ", state.Skills.Select(s => $"{s.SkillName} Lv{s.Level} CD{s.CurrentCD:0.##}")));
-                        if (state.Effects.Count > 0) details.Add("状态: " + string.Join(" / ", state.Effects.Select(e => $"{e.EffectName} 剩余{e.RemainDuration:0.##}")));
+                        if (state.Skills.Count > 0) details.Add("技能: " + string.Join(" / ", state.Skills.Select(s => s.CurrentCD > 0 ? $"{s.SkillName} Lv{s.Level} CD{s.CurrentCD:0.##}" : $"{s.SkillName} Lv{s.Level}")));
+                        if (state.Effects.Count > 0) details.Add("状态: " + string.Join(" / ", state.Effects.Select(e => e.RemainDurationTurn > 0 ? $"{e.EffectName} 剩余{e.RemainDurationTurn}R" : e.RemainDuration > 0 ? $"{e.EffectName} 剩余{e.RemainDuration:0.##}" : e.EffectName)));
                         if (details.Count > 0) builder.AppendLine("\r\n  " + string.Join("\r\n  ", details));
                         else builder.AppendLine();
                     }

--- a/Model/Framework/RoundRecord.cs
+++ b/Model/Framework/RoundRecord.cs
@@ -47,6 +47,11 @@ namespace FunGame.Core.Model.Framework
         public Dictionary<Guid, string> TeamMap { get; set; } = [];
 
         /// <summary>
+        /// 所有角色的最终统计数据（游戏结束时由队列写入所有参与角色的 <see cref="CharacterStatistics"/>，其他回合为空）
+        /// </summary>
+        public Dictionary<Character, CharacterStatistics> CharacterStatistics { get; set; } = [];
+
+        /// <summary>
         /// 游戏结束信息（胜者与排名条目，按名次顺序排列；游戏结束时由队列写入，非游戏结束回合为空）
         /// </summary>
         public List<RankingEntry> GameResult { get; set; } = [];
@@ -125,6 +130,19 @@ namespace FunGame.Core.Model.Framework
                 }
             }
 
+            // 角色最终统计数据（游戏结束时写入）
+            if (CharacterStatistics.Count > 0)
+            {
+                builder.AppendLine("");
+                builder.AppendLine("=== 角色统计 ===");
+                foreach (KeyValuePair<Character, CharacterStatistics> kv in CharacterStatistics)
+                {
+                    CharacterStatistics s = kv.Value;
+                    string teamTag = TeamMap.TryGetValue(kv.Key.Guid, out string? team) && team != "" ? $"[{team}] " : "";
+                    builder.AppendLine($"{teamTag}[ {kv.Key} ] 伤害 {s.TotalDamage:0.##} / 治疗 {s.TotalHeal:0.##} / 击杀 {s.Kills} / 死亡 {s.Deaths} / 助攻 {s.Assists} / 金币 {s.TotalEarnedMoney}");
+                }
+            }
+
             // 开局（第 1 回合）与游戏结束回合输出全角色状态（装备/物品/技能/状态栏）
             if (Round == 1 || GameResult.Count > 0)
             {
@@ -137,7 +155,8 @@ namespace FunGame.Core.Model.Framework
                         string teamTag = TeamMap.TryGetValue(state.Character.Guid, out string? team) && team != "" ? $"[{team}] " : "";
                         builder.Append($"{teamTag}[ {state.Character} ] HP {state.HP:0.##}/{state.MaxHP:0.##} MP {state.MP:0.##}/{state.MaxMP:0.##} EP {state.EP:0.##}");
                         List<string> details = [];
-                        if (state.Equipments.Count > 0) details.Add("装备: " + string.Join(" / ", state.Equipments.Select(e => $"{e.Key}={e.Value}")));
+                        if (state.EquipmentsDetail.Count > 0) details.Add("装备: " + string.Join(" / ", state.EquipmentsDetail.Select(e => $"{ItemSet.GetEquipSlotTypeName(e.Slot)}={e.ItemName}")));
+                        else if (state.Equipments.Count > 0) details.Add("装备: " + string.Join(" / ", state.Equipments.Select(e => $"{ItemSet.GetEquipSlotTypeName(e.Key)}={e.Value}")));
                         if (state.Items.Count > 0) details.Add("物品: " + string.Join(" / ", state.Items.Select(i => i.ItemName)));
                         if (state.Skills.Count > 0) details.Add("技能: " + string.Join(" / ", state.Skills.Select(s => $"{s.SkillName} Lv{s.Level} CD{s.CurrentCD:0.##}")));
                         if (state.Effects.Count > 0) details.Add("状态: " + string.Join(" / ", state.Effects.Select(e => $"{e.EffectName} 剩余{e.RemainDuration:0.##}")));
@@ -206,6 +225,7 @@ namespace FunGame.Core.Model.Framework
             snapshot.AllCharacters = [.. AllCharacters];
             snapshot.TeamMap = new(TeamMap);
             snapshot.GameResult = [.. GameResult];
+            snapshot.CharacterStatistics = new(CharacterStatistics);
             snapshot.TotalTime = TotalTime;
             return snapshot;
         }

--- a/Model/Framework/RoundRecord.cs
+++ b/Model/Framework/RoundRecord.cs
@@ -8,6 +8,10 @@ namespace FunGame.Core.Model.Framework
     {
         public int Round { get; set; } = round;
         public Character Actor { get; set; } = new();
+        /// <summary>
+        /// 本回合内的全部操作记录（决策点系统允许一回合多次操作，按执行顺序排列，<see cref="ActionRecord.ActionIndex"/> 从 1 开始）
+        /// </summary>
+        public List<ActionRecord> Actions { get; } = [];
         public HashSet<CharacterActionType> ActionTypes { get; } = [];
         public Dictionary<CharacterActionType, List<Character>> Targets { get; } = [];
         public Dictionary<CharacterActionType, Skill> Skills { get; } = [];
@@ -32,6 +36,21 @@ namespace FunGame.Core.Model.Framework
         public List<Skill> RoundRewards { get; set; } = [];
         public List<string> OtherMessages { get; set; } = [];
 
+        /// <summary>
+        /// 全角色清单（开局时由队列写入所有参与角色，供回放端在开局获取完整角色列表；后续回合由序列化时动态收集出现的角色）
+        /// </summary>
+        public List<Character> AllCharacters { get; set; } = [];
+
+        /// <summary>
+        /// 回合结束时的游戏总时间（状态推算的时间轴基准）
+        /// </summary>
+        public double TotalTime { get; set; } = 0;
+
+        /// <summary>
+        /// 状态检查点（周期性生成的全角色状态快照列表，每个元素为一个角色状态，作为状态推算的精确基准；非检查点回合为 null）
+        /// </summary>
+        public List<CharacterStateSnapshot>? Checkpoint { get; set; } = null;
+
         public void AddApplyEffects(Character character, params IEnumerable<EffectType> types)
         {
             if (ApplyEffects.TryGetValue(character, out List<EffectType>? list) && list != null)
@@ -51,12 +70,12 @@ namespace FunGame.Core.Model.Framework
             builder.AppendLine($"=== Round {Round} ===");
             if (RoundRewards.Count > 0)
             {
-                builder.AppendLine($"[ {Actor} ] 回合奖励 -> {string.Join(" / ", RoundRewards.Select(s => s.Description)).Trim()}");
+                builder.AppendLine($"[ {Actor} ] 回合奖励 -> {string.Join(" / ", RoundRewards.Select(s => s.Name)).Trim()}");
             }
 
             if (Effects.Count > 0)
             {
-                builder.AppendLine($"[ {Actor} ] 发动了技能：{string.Join("，", Effects.Where(kv => kv.Key == Actor).Select(e => e.Value.Name))}");
+                builder.AppendLine($"[ {Actor} ] 发动了技能：{string.Join("，", Effects.Where(kv => kv.Key.Guid == Actor.Guid).Select(e => e.Value.Name))}");
             }
 
             foreach (CharacterActionType type in ActionTypes)
@@ -160,7 +179,7 @@ namespace FunGame.Core.Model.Framework
                         hasEvaded = "技能免疫";
                     }
                 }
-                if (IsImmune.TryGetValue(target, out bool isImmune) && isImmune && target != Actor)
+                if (IsImmune.TryGetValue(target, out bool isImmune) && isImmune && target.Guid != Actor.Guid)
                 {
                     hasDamage = "免疫";
                 }
@@ -216,6 +235,17 @@ namespace FunGame.Core.Model.Framework
             {
                 snapshot.Skills[kv.Key] = kv.Value;
             }
+            foreach (ActionRecord action in Actions)
+            {
+                snapshot.Actions.Add(action.Snapshot());
+            }
+            // 检查点列表拷贝（元素共享，防快照后对列表结构的修改）
+            if (Checkpoint != null)
+            {
+                snapshot.Checkpoint = [.. Checkpoint];
+            }
+            snapshot.AllCharacters = [.. AllCharacters];
+            snapshot.TotalTime = TotalTime;
             return snapshot;
         }
     }

--- a/Model/Framework/RoundRecord.cs
+++ b/Model/Framework/RoundRecord.cs
@@ -42,6 +42,16 @@ namespace FunGame.Core.Model.Framework
         public List<Character> AllCharacters { get; set; } = [];
 
         /// <summary>
+        /// 角色队伍归属映射（角色 Guid -> 队伍名；团队模式开局时由队列写入，非团队模式为空）
+        /// </summary>
+        public Dictionary<Guid, string> TeamMap { get; set; } = [];
+
+        /// <summary>
+        /// 游戏结束信息（胜者与排名条目，按名次顺序排列；游戏结束时由队列写入，非游戏结束回合为空）
+        /// </summary>
+        public List<RankingEntry> GameResult { get; set; } = [];
+
+        /// <summary>
         /// 回合结束时的游戏总时间（状态推算的时间轴基准）
         /// </summary>
         public double TotalTime { get; set; } = 0;
@@ -73,52 +83,13 @@ namespace FunGame.Core.Model.Framework
                 builder.AppendLine($"[ {Actor} ] 回合奖励 -> {string.Join(" / ", RoundRewards.Select(s => s.Name)).Trim()}");
             }
 
-            if (Effects.Count > 0)
+            // 操作流：按执行顺序逐条输出
+            foreach (ActionRecord action in Actions)
             {
-                builder.AppendLine($"[ {Actor} ] 发动了技能：{string.Join("，", Effects.Where(kv => kv.Key.Guid == Actor.Guid).Select(e => e.Value.Name))}");
+                builder.AppendLine(action.ToString());
             }
 
-            foreach (CharacterActionType type in ActionTypes)
-            {
-                if (!Targets.TryGetValue(type, out List<Character>? targets) || targets is null)
-                {
-                    targets = [];
-                }
-
-                if (type == CharacterActionType.NormalAttack)
-                {
-                    builder.Append($"[ {Actor} ] {Actor.NormalAttack.Name} -> ");
-                }
-                else if (type == CharacterActionType.CastSkill || type == CharacterActionType.CastSuperSkill || type == CharacterActionType.PreCastSkill)
-                {
-                    if (Skills.TryGetValue(type, out Skill? skill) && skill != null)
-                    {
-                        string skillCost = SkillsCost.TryGetValue(skill, out string? cost) ? $"（{cost}）" : "";
-                        builder.Append($"[ {Actor} ] {skill.Name}{skillCost} -> ");
-                    }
-                    else
-                    {
-                        builder.Append($"技能 -> ");
-                    }
-                }
-                else if (type == CharacterActionType.UseItem)
-                {
-                    if (Items.TryGetValue(type, out Item? item) && item != null)
-                    {
-                        string itemCost = ItemsCost.TryGetValue(item, out string? cost) ? $"（{cost}）" : "";
-                        builder.Append($"[ {Actor} ] {item.Name}{itemCost} -> ");
-                    }
-                    else
-                    {
-                        builder.Append($"技能 -> ");
-                    }
-                }
-                builder.AppendLine(string.Join(" / ", GetTargetsState(type, targets)));
-            }
-
-            if (DeathContinuousKilling.Count > 0) builder.AppendLine($"{string.Join("\r\n", DeathContinuousKilling)}");
-            if (ActorContinuousKilling.Count > 0) builder.AppendLine($"{string.Join("\r\n", ActorContinuousKilling)}");
-            if (Assists.Count > 0) builder.AppendLine($"本回合助攻：[ {string.Join(" ] / [ ", Assists)} ]");
+            // 回合级杂项消息
             if (OtherMessages.Count > 0) builder.AppendLine(string.Join("\r\n", OtherMessages));
 
             if (CastTime > 0)
@@ -140,55 +111,43 @@ namespace FunGame.Core.Model.Framework
                 builder.AppendLine($"[ {character} ] 复活了");
             }
 
-            return builder.ToString();
-        }
-
-        private List<string> GetTargetsState(CharacterActionType type, List<Character> targets)
-        {
-            List<string> strings = [];
-            foreach (Character target in targets.Distinct())
+            // 游戏结束信息
+            if (GameResult.Count > 0)
             {
-                string hasDamage = "";
-                string hasHeal = "";
-                string hasEffect = "";
-                string hasEvaded = "";
-                if (Damages.TryGetValue(target, out double damage))
+                builder.AppendLine("");
+                builder.AppendLine("=== 游戏结束 ===");
+                foreach (RankingEntry entry in GameResult)
                 {
-                    hasDamage = $"伤害：{damage:0.##}";
-                    if (IsCritical.TryGetValue(target, out bool isCritical) && isCritical)
-                    {
-                        hasDamage = "暴击，" + hasDamage;
-                    }
+                    string name = entry.IsTeam ? $"[ {entry.Team} ] 团队" : $"[ {entry.Character} ]";
+                    string stats = entry.IsTeam ? $"得分 {entry.Score} / 击杀 {entry.Kills} / 助攻 {entry.Assists}" :
+                        $"击杀 {entry.Kills} / 死亡 {entry.Deaths} / 助攻 {entry.Assists}{(entry.TotalEarnedMoney > 0 ? $" / 赚取 {entry.TotalEarnedMoney} {General.GameplayEquilibriumConstant.InGameCurrency}" : "")}";
+                    builder.AppendLine($"{(entry.IsWinner ? "★ " : "")}{entry.Rank} 名：{name}（{stats}）");
                 }
-                if (Heals.TryGetValue(target, out double heals))
-                {
-                    hasHeal = $"治疗：{heals:0.##}";
-                }
-                if (ApplyEffects.TryGetValue(target, out List<EffectType>? effectTypes) && effectTypes != null)
-                {
-                    hasEffect = $"施加：{string.Join(" + ", effectTypes.Select(SkillSet.GetEffectTypeName))}";
-                }
-                if (IsEvaded.TryGetValue(target, out bool isEvaded) && isEvaded)
-                {
-                    if (type == CharacterActionType.NormalAttack)
-                    {
-                        hasEvaded = hasDamage == "" ? "完美闪避" : "闪避";
-                    }
-                    else if ((type == CharacterActionType.PreCastSkill || type == CharacterActionType.CastSkill || type == CharacterActionType.CastSuperSkill))
-                    {
-                        hasEvaded = "技能免疫";
-                    }
-                }
-                if (IsImmune.TryGetValue(target, out bool isImmune) && isImmune && target.Guid != Actor.Guid)
-                {
-                    hasDamage = "免疫";
-                }
-                string[] strs = [hasDamage, hasHeal, hasEffect, hasEvaded];
-                strs = [.. strs.Where(s => s != "")];
-                if (strs.Length == 0) strings.Add($"[ {target} ]");
-                else strings.Add($"[ {target}（{string.Join(" / ", strs)}）]");
             }
-            return strings;
+
+            // 开局（第 1 回合）与游戏结束回合输出全角色状态（装备/物品/技能/状态栏）
+            if (Round == 1 || GameResult.Count > 0)
+            {
+                if (Checkpoint != null && Checkpoint.Count > 0)
+                {
+                    builder.AppendLine("");
+                    builder.AppendLine("=== 角色状态 ===");
+                    foreach (CharacterStateSnapshot state in Checkpoint)
+                    {
+                        string teamTag = TeamMap.TryGetValue(state.Character.Guid, out string? team) && team != "" ? $"[{team}] " : "";
+                        builder.Append($"{teamTag}[ {state.Character} ] HP {state.HP:0.##}/{state.MaxHP:0.##} MP {state.MP:0.##}/{state.MaxMP:0.##} EP {state.EP:0.##}");
+                        List<string> details = [];
+                        if (state.Equipments.Count > 0) details.Add("装备: " + string.Join(" / ", state.Equipments.Select(e => $"{e.Key}={e.Value}")));
+                        if (state.Items.Count > 0) details.Add("物品: " + string.Join(" / ", state.Items.Select(i => i.ItemName)));
+                        if (state.Skills.Count > 0) details.Add("技能: " + string.Join(" / ", state.Skills.Select(s => $"{s.SkillName} Lv{s.Level} CD{s.CurrentCD:0.##}")));
+                        if (state.Effects.Count > 0) details.Add("状态: " + string.Join(" / ", state.Effects.Select(e => $"{e.EffectName} 剩余{e.RemainDuration:0.##}")));
+                        if (details.Count > 0) builder.AppendLine("\r\n  " + string.Join("\r\n  ", details));
+                        else builder.AppendLine();
+                    }
+                }
+            }
+
+            return builder.ToString();
         }
 
         /// <summary>
@@ -245,6 +204,8 @@ namespace FunGame.Core.Model.Framework
                 snapshot.Checkpoint = [.. Checkpoint];
             }
             snapshot.AllCharacters = [.. AllCharacters];
+            snapshot.TeamMap = new(TeamMap);
+            snapshot.GameResult = [.. GameResult];
             snapshot.TotalTime = TotalTime;
             return snapshot;
         }

--- a/Model/Queue/GamingQueue.cs
+++ b/Model/Queue/GamingQueue.cs
@@ -727,12 +727,21 @@ namespace FunGame.Core.Model.Queue
                 TotalRound++;
                 // 将上一回合记录以结构快照的形式归档，防止后续写入（例如时间流逝中的复活结算）污染已归档的历史记录
                 if (TotalRound > 1) Rounds.Add(LastRound.Snapshot());
-                LastRound = new(TotalRound) { Actor = character };
+                LastRound = new(TotalRound)
+                {
+                    Actor = character, // 每回合记录所有参与角色与队伍归属，供回放端任意回合自包含获取（团队模式 TeamMap 含队伍名，其他模式为空）
+                    AllCharacters = [.. _allCharacters.Union(_queue).Distinct()]
+                };
+                foreach (Character c in LastRound.AllCharacters)
+                {
+                    string? teamName = GetCharacterTeamName(c);
+                    if (teamName != null) LastRound.TeamMap[c.Guid] = teamName;
+                }
 
                 if (TotalRound == 1)
                 {
-                    // 开局记录所有参与角色，供回放端在开局时获取完整角色清单
-                    LastRound.AllCharacters = [.. _allCharacters.Union(_queue).Distinct()];
+                    // 开局状态检查点（装备/物品/技能/状态栏）
+                    LastRound.Checkpoint = CreateStateCheckpoint();
                     // 触发游戏开始事件
                     OnGameStartEvent();
                     Effect[] effects = [.. _queue.SelectMany(c => c.Effects).Where(e => e.IsInEffect).OrderByDescending(e => e.Priority)];
@@ -1339,6 +1348,11 @@ namespace FunGame.Core.Model.Queue
                     // 创建当前操作记录，每次行动对应一条操作记录
                     if (type != CharacterActionType.None && type != CharacterActionType.EndTurn)
                     {
+                        // 上一轮尝试若未成功执行（未标记失败且未决策，即被取消），移除其记录，避免空记录残留
+                        if (_currentAction != null && LastRound.Actions.Count > 0 && ReferenceEquals(LastRound.Actions[^1], _currentAction) && _currentAction.IsSuccess)
+                        {
+                            LastRound.Actions.RemoveAt(LastRound.Actions.Count - 1);
+                        }
                         _currentAction = new(TotalRound)
                         {
                             Actor = character,
@@ -1349,6 +1363,11 @@ namespace FunGame.Core.Model.Queue
                     }
                     else
                     {
+                        // 若上一轮尝试被取消（未标记失败），移除其空记录，避免残留
+                        if (_currentAction != null && LastRound.Actions.Count > 0 && ReferenceEquals(LastRound.Actions[^1], _currentAction) && _currentAction.IsSuccess)
+                        {
+                            LastRound.Actions.RemoveAt(LastRound.Actions.Count - 1);
+                        }
                         _currentAction = null;
                     }
 
@@ -1566,7 +1585,11 @@ namespace FunGame.Core.Model.Queue
                                         }
                                         else
                                         {
-                                            if (IsDebug) WriteLine($"[ {character} ] 想要吟唱 [ {skill.Name} ]，但是没有目标！");
+                                            string failMsg = $"[ {character} ] 想要吟唱 [ {skill.Name} ]，但是没有目标！";
+                                            LastRound.OtherMessages.Add(failMsg);
+                                            _currentAction?.Skill = skill;
+                                            RecordCurrentActionFailure(failMsg);
+                                            if (IsDebug) WriteLine(failMsg);
                                         }
                                     }
                                 }
@@ -1683,7 +1706,11 @@ namespace FunGame.Core.Model.Queue
                                         }
                                         else
                                         {
-                                            if (IsDebug) WriteLine($"[ {character} ] 想要释放 [ {skill.Name} ]，但是没有目标！");
+                                            string failMsg = $"[ {character} ] 想要释放 [ {skill.Name} ]，但是没有目标！";
+                                            LastRound.OtherMessages.Add(failMsg);
+                                            _currentAction?.Skill = skill;
+                                            RecordCurrentActionFailure(failMsg);
+                                            if (IsDebug) WriteLine(failMsg);
                                         }
                                     }
                                 }
@@ -1774,7 +1801,20 @@ namespace FunGame.Core.Model.Queue
                             {
                                 if (!hasTarget)
                                 {
-                                    WriteLine($"[ {character} ] 想要释放 [ {skill.Name} ]，但是没有目标！");
+                                    string failMsg = $"[ {character} ] 想要释放 [ {skill.Name} ]，但是没有目标！";
+                                    LastRound.OtherMessages.Add(failMsg);
+                                    _currentAction?.Skill = skill;
+                                    RecordCurrentActionFailure(failMsg);
+                                    WriteLine(failMsg);
+                                }
+                                else
+                                {
+                                    // 有目标但无法释放（魔法值不足/技能冷却等），记录为明确失败
+                                    string failMsg = $"[ {character} ] 想要释放 [ {skill.Name} ]，但无法释放（魔法值不足或技能冷却中）！";
+                                    LastRound.OtherMessages.Add(failMsg);
+                                    _currentAction?.Skill = skill;
+                                    RecordCurrentActionFailure(failMsg);
+                                    WriteLine(failMsg);
                                 }
                                 WriteLine($"[ {character} ] 放弃释放技能！");
                                 character.CharacterState = CharacterState.Actionable;
@@ -1787,7 +1827,11 @@ namespace FunGame.Core.Model.Queue
                         }
                         else
                         {
-                            // 原吟唱的技能丢失（被打断或者被取消），允许角色再次决策
+                            // 原吟唱的技能丢失（被打断或者被取消），记录为明确失败并允许角色再次决策
+                            string failMsg = $"[ {character} ] 吟唱被打断，技能丢失！";
+                            LastRound.OtherMessages.Add(failMsg);
+                            RecordCurrentActionFailure(failMsg);
+                            if (IsDebug) WriteLine(failMsg);
                             character.CharacterState = CharacterState.Actionable;
                             character.UpdateCharacterState();
                         }
@@ -1946,6 +1990,15 @@ namespace FunGame.Core.Model.Queue
                                     effect.AlterHardnessTimeAfterCastSkill(character, skill, ref baseTime, ref isCheckProtected);
                                 }
                             }
+                            else
+                            {
+                                // 物品使用失败（没有目标等），记录为明确失败
+                                string failMsg = $"[ {character} ] 想要使用物品 [ {item.Name} ]，但使用失败！";
+                                LastRound.OtherMessages.Add(failMsg);
+                                _currentAction?.Item = item;
+                                RecordCurrentActionFailure(failMsg);
+                                if (IsDebug) WriteLine(failMsg);
+                            }
                         }
                     }
                     else if (type == CharacterActionType.EndTurn)
@@ -1973,6 +2026,15 @@ namespace FunGame.Core.Model.Queue
 
                 if (!decided && (isAI || cancelTimes == 0))
                 {
+                    // 行动被取消（AI 决策次数耗尽等），取消的操作不予记录、不予外发
+                    if (_currentAction != null)
+                    {
+                        if (LastRound.Actions.Count > 0 && ReferenceEquals(LastRound.Actions[^1], _currentAction) && _currentAction.IsSuccess)
+                        {
+                            LastRound.Actions.RemoveAt(LastRound.Actions.Count - 1);
+                        }
+                        _currentAction = null;
+                    }
                     endTurn = true;
                     baseTime += 3;
                     type = CharacterActionType.EndTurn;
@@ -2004,6 +2066,8 @@ namespace FunGame.Core.Model.Queue
                 if (_currentAction != null)
                 {
                     RoundRecordSink?.SendAction(_currentAction.Snapshot());
+                    // 操作已成功结算，清空当前操作，避免与下一轮行动混淆
+                    _currentAction = null;
                 }
             }
 
@@ -2061,6 +2125,15 @@ namespace FunGame.Core.Model.Queue
                 OnTurnEndEvent(character, dp);
 
                 AfterTurn(character);
+
+                // 游戏结束时强制生成状态检查点（若该回合未按周期生成，用于输出最终角色状态）
+                if (LastRound.Checkpoint == null)
+                {
+                    LastRound.Checkpoint = CreateStateCheckpoint();
+                }
+
+                // 游戏结束回合归档（无下一回合，NextCharacter 不会归档本回合记录）
+                Rounds.Add(LastRound.Snapshot());
 
                 _isInRound = false;
                 _currentAction = null;
@@ -2165,6 +2238,13 @@ namespace FunGame.Core.Model.Queue
         }
 
         /// <summary>
+        /// 获取角色所属队伍名（团队模式返回队伍名，其他模式返回 null；用于回合记录的角色队伍归属标记）
+        /// </summary>
+        /// <param name="character">角色</param>
+        /// <returns>队伍名或 null</returns>
+        protected virtual string? GetCharacterTeamName(Character character) => null;
+
+        /// <summary>
         /// 生成全角色状态检查点（每个角色一条状态快照，含 HP/MP/EP、装备栏、技能状态、状态栏特效）
         /// </summary>
         /// <returns></returns>
@@ -2199,6 +2279,12 @@ namespace FunGame.Core.Model.Queue
                 foreach (Skill skill in character.Skills)
                 {
                     state.Skills.Add(new SkillStateSnapshot { SkillId = skill.Id, SkillName = skill.Name, Level = skill.Level, CurrentCD = skill.CurrentCD });
+                }
+
+                // 物品栏（背包）
+                foreach (Item item in character.Items)
+                {
+                    state.Items.Add(new ItemStateSnapshot { ItemId = item.Id, ItemName = item.Name });
                 }
 
                 // 状态栏特效
@@ -2878,21 +2964,23 @@ namespace FunGame.Core.Model.Queue
                 money += (coefficient + 1) * 60;
                 string termination = CharacterSet.GetContinuousKilling(coefficient);
                 string msg = $"[ {killer} ] 终结了 [ {death} ]{(termination != "" ? " 的" + termination : "")}，获得 {money} {GameplayEquilibriumConstant.InGameCurrency}！";
-                LastRound.DeathContinuousKilling.Add(msg);
                 if (assists.Length > 1)
                 {
                     msg += "助攻：[ " + string.Join(" ] / [ ", assists.Where(c => c != killer)) + " ]";
                 }
+                LastRound.DeathContinuousKilling.Add(msg);
+                _currentAction?.Messages.Add(msg);
                 WriteLine(msg);
             }
             else
             {
                 string msg = $"[ {killer} ] 杀死了 [ {death} ]，获得 {money} {GameplayEquilibriumConstant.InGameCurrency}！";
-                LastRound.DeathContinuousKilling.Add(msg);
                 if (assists.Length > 1)
                 {
                     msg += "助攻：[ " + string.Join(" ] / [ ", assists.Where(c => c != killer)) + " ]";
                 }
+                LastRound.DeathContinuousKilling.Add(msg);
+                _currentAction?.Messages.Add(msg);
                 WriteLine(msg);
             }
             dr.Assists = assists;
@@ -2906,6 +2994,7 @@ namespace FunGame.Core.Model.Queue
                 string firstKill = $"[ {killer} ] 拿下了第一滴血！额外奖励 200 {GameplayEquilibriumConstant.InGameCurrency}！！";
                 WriteLine(firstKill);
                 LastRound.ActorContinuousKilling.Add(firstKill);
+                _currentAction?.Messages.Add(firstKill);
             }
 
             if (!_earnedMoney.TryAdd(killer, money)) _earnedMoney[killer] += money;
@@ -2933,6 +3022,7 @@ namespace FunGame.Core.Model.Queue
             if (actorContinuousKilling != "")
             {
                 LastRound.ActorContinuousKilling.Add(actorContinuousKilling);
+                _currentAction?.Messages.Add(actorContinuousKilling);
                 WriteLine(actorContinuousKilling);
             }
 
@@ -2965,6 +3055,7 @@ namespace FunGame.Core.Model.Queue
                     _continuousKilling[killer] -= 1;
                 }
                 LastRound.DeathContinuousKilling.Add(msg);
+                _currentAction?.Messages.Add(msg);
                 WriteLine(msg);
             }
 

--- a/Model/Queue/GamingQueue.cs
+++ b/Model/Queue/GamingQueue.cs
@@ -2132,6 +2132,9 @@ namespace FunGame.Core.Model.Queue
                     LastRound.Checkpoint = CreateStateCheckpoint();
                 }
 
+                // 游戏结束时加入所有角色的最终统计数据
+                LastRound.CharacterStatistics = new(_stats);
+
                 // 游戏结束回合归档（无下一回合，NextCharacter 不会归档本回合记录）
                 Rounds.Add(LastRound.Snapshot());
 
@@ -2266,14 +2269,38 @@ namespace FunGame.Core.Model.Queue
                     MR = character.MR
                 };
 
-                // 装备栏（物品 ID）
+                // 装备栏（物品 ID + 名字明细）
                 EquipSlot slot = character.EquipSlot;
-                if (slot.Weapon != null) state.Equipments[EquipSlotType.Weapon] = slot.Weapon.Id;
-                if (slot.Armor != null) state.Equipments[EquipSlotType.Armor] = slot.Armor.Id;
-                if (slot.Shoes != null) state.Equipments[EquipSlotType.Shoes] = slot.Shoes.Id;
-                if (slot.Accessory1 != null) state.Equipments[EquipSlotType.Accessory1] = slot.Accessory1.Id;
-                if (slot.Accessory2 != null) state.Equipments[EquipSlotType.Accessory2] = slot.Accessory2.Id;
-                if (slot.MagicCardPack != null) state.Equipments[EquipSlotType.MagicCardPack] = slot.MagicCardPack.Id;
+                if (slot.Weapon != null)
+                {
+                    state.Equipments[EquipSlotType.Weapon] = slot.Weapon.Id;
+                    state.EquipmentsDetail.Add(new EquipmentStateSnapshot { Slot = EquipSlotType.Weapon, ItemId = slot.Weapon.Id, ItemName = slot.Weapon.Name });
+                }
+                if (slot.Armor != null)
+                {
+                    state.Equipments[EquipSlotType.Armor] = slot.Armor.Id;
+                    state.EquipmentsDetail.Add(new EquipmentStateSnapshot { Slot = EquipSlotType.Armor, ItemId = slot.Armor.Id, ItemName = slot.Armor.Name });
+                }
+                if (slot.Shoes != null)
+                {
+                    state.Equipments[EquipSlotType.Shoes] = slot.Shoes.Id;
+                    state.EquipmentsDetail.Add(new EquipmentStateSnapshot { Slot = EquipSlotType.Shoes, ItemId = slot.Shoes.Id, ItemName = slot.Shoes.Name });
+                }
+                if (slot.Accessory1 != null)
+                {
+                    state.Equipments[EquipSlotType.Accessory1] = slot.Accessory1.Id;
+                    state.EquipmentsDetail.Add(new EquipmentStateSnapshot { Slot = EquipSlotType.Accessory1, ItemId = slot.Accessory1.Id, ItemName = slot.Accessory1.Name });
+                }
+                if (slot.Accessory2 != null)
+                {
+                    state.Equipments[EquipSlotType.Accessory2] = slot.Accessory2.Id;
+                    state.EquipmentsDetail.Add(new EquipmentStateSnapshot { Slot = EquipSlotType.Accessory2, ItemId = slot.Accessory2.Id, ItemName = slot.Accessory2.Name });
+                }
+                if (slot.MagicCardPack != null)
+                {
+                    state.Equipments[EquipSlotType.MagicCardPack] = slot.MagicCardPack.Id;
+                    state.EquipmentsDetail.Add(new EquipmentStateSnapshot { Slot = EquipSlotType.MagicCardPack, ItemId = slot.MagicCardPack.Id, ItemName = slot.MagicCardPack.Name });
+                }
 
                 // 技能状态
                 foreach (Skill skill in character.Skills)

--- a/Model/Queue/GamingQueue.cs
+++ b/Model/Queue/GamingQueue.cs
@@ -116,6 +116,21 @@ namespace FunGame.Core.Model.Queue
         public RoundRecord LastRound { get; set; } = new(0);
 
         /// <summary>
+        /// 当前正在执行的操作记录
+        /// </summary>
+        public ActionRecord? CurrentAction => _currentAction;
+
+        /// <summary>
+        /// 回合记录外发通道（可为 null；设置后操作完成/回合决策完成时即时外发）
+        /// </summary>
+        public IRoundRecordSink? RoundRecordSink { get; set; } = null;
+
+        /// <summary>
+        /// 状态检查点生成间隔（回合数）；大于 0 时每 N 回合在回合记录上附带一次全角色状态快照，0 或负数表示不生成
+        /// </summary>
+        public int CheckpointInterval { get; set; } = 50;
+
+        /// <summary>
         /// 所有回合的记录
         /// </summary>
         public List<RoundRecord> Rounds { get; } = [];
@@ -306,6 +321,11 @@ namespace FunGame.Core.Model.Queue
         /// 使用的地图
         /// </summary>
         protected GameMap? _map = null;
+
+        /// <summary>
+        /// 当前正在执行的操作记录
+        /// </summary>
+        protected ActionRecord? _currentAction = null;
 
         #endregion
 
@@ -711,6 +731,8 @@ namespace FunGame.Core.Model.Queue
 
                 if (TotalRound == 1)
                 {
+                    // 开局记录所有参与角色，供回放端在开局时获取完整角色清单
+                    LastRound.AllCharacters = [.. _allCharacters.Union(_queue).Distinct()];
                     // 触发游戏开始事件
                     OnGameStartEvent();
                     Effect[] effects = [.. _queue.SelectMany(c => c.Effects).Where(e => e.IsInEffect).OrderByDescending(e => e.Priority)];
@@ -1314,6 +1336,22 @@ namespace FunGame.Core.Model.Queue
                         effect.OnCharacterActionStart(character, dp, type);
                     }
 
+                    // 创建当前操作记录，每次行动对应一条操作记录
+                    if (type != CharacterActionType.None && type != CharacterActionType.EndTurn)
+                    {
+                        _currentAction = new(TotalRound)
+                        {
+                            Actor = character,
+                            ActionType = type,
+                            ActionIndex = LastRound.Actions.Count + 1
+                        };
+                        LastRound.Actions.Add(_currentAction);
+                    }
+                    else
+                    {
+                        _currentAction = null;
+                    }
+
                     if (type == CharacterActionType.Move)
                     {
                         if (_map != null)
@@ -1361,13 +1399,17 @@ namespace FunGame.Core.Model.Queue
                         }
                         else if (dp.CurrentDecisionPoints < costDP)
                         {
-                            LastRound.OtherMessages.Add($"[ {character} ] 想要发起普通攻击，但决策点不足，无法使用普通攻击！");
-                            if (IsDebug) WriteLine($"[ {character} ] 想要发起普通攻击，但决策点不足，无法使用普通攻击！");
+                            string failMsg = $"[ {character} ] 想要发起普通攻击，但决策点不足，无法使用普通攻击！";
+                            LastRound.OtherMessages.Add(failMsg);
+                            RecordCurrentActionFailure(failMsg);
+                            if (IsDebug) WriteLine(failMsg);
                         }
                         else if (!dp.CheckActionTypeQuota(CharacterActionType.NormalAttack))
                         {
-                            LastRound.OtherMessages.Add($"[ {character} ] 想要发起普通攻击，但该回合使用普通攻击的次数已超过决策点配额，无法再次使用普通攻击！");
-                            if (IsDebug) WriteLine($"[ {character} ] 想要发起普通攻击，但该回合使用普通攻击的次数已超过决策点配额，无法再次使用普通攻击！");
+                            string failMsg = $"[ {character} ] 想要发起普通攻击，但该回合使用普通攻击的次数已超过决策点配额，无法再次使用普通攻击！";
+                            LastRound.OtherMessages.Add(failMsg);
+                            RecordCurrentActionFailure(failMsg);
+                            if (IsDebug) WriteLine(failMsg);
                         }
                         else
                         {
@@ -1392,6 +1434,12 @@ namespace FunGame.Core.Model.Queue
                             {
                                 LastRound.Targets[CharacterActionType.NormalAttack] = [.. targets];
                                 LastRound.ActionTypes.Add(CharacterActionType.NormalAttack);
+                                if (_currentAction != null)
+                                {
+                                    _currentAction.Targets.AddRange(targets);
+                                    _currentAction.DecisionPointsCost = costDP;
+                                    _currentAction.Cost = $"-{costDP:0.##} DP";
+                                }
                                 _stats[statsCharacter].UseDecisionPoints += costDP;
                                 _stats[statsCharacter].TurnDecisions++;
                                 dp.AddActionType(CharacterActionType.NormalAttack);
@@ -1459,8 +1507,10 @@ namespace FunGame.Core.Model.Queue
                                     int costDP = dp.GetActionPointCost(type, skill);
                                     if (dp.CurrentDecisionPoints < costDP)
                                     {
-                                        LastRound.OtherMessages.Add($"[ {character} ] 想要释放 [ {skill.Name} ]，但决策点不足，无法释放技能！");
-                                        if (IsDebug) WriteLine($"[ {character} ] 想要释放 [ {skill.Name} ]，但决策点不足，无法释放技能！");
+                                        string failMsg = $"[ {character} ] 想要释放 [ {skill.Name} ]，但决策点不足，无法释放技能！";
+                                        LastRound.OtherMessages.Add(failMsg);
+                                        RecordCurrentActionFailure(failMsg);
+                                        if (IsDebug) WriteLine(failMsg);
                                     }
                                     else if (CheckCanCast(character, skill, out double cost))
                                     {
@@ -1486,6 +1536,12 @@ namespace FunGame.Core.Model.Queue
                                             LastRound.Targets[CharacterActionType.PreCastSkill] = [.. targets];
                                             LastRound.ActionTypes.Add(CharacterActionType.PreCastSkill);
                                             LastRound.Effects[character] = skill;
+                                            if (_currentAction != null)
+                                            {
+                                                _currentAction.Skill = skill;
+                                                _currentAction.Targets.AddRange(targets);
+                                                _currentAction.DecisionPointsCost = costDP;
+                                            }
                                             _stats[statsCharacter].UseDecisionPoints += costDP;
                                             _stats[statsCharacter].TurnDecisions++;
                                             dp.AddActionType(CharacterActionType.PreCastSkill, skill);
@@ -1561,6 +1617,12 @@ namespace FunGame.Core.Model.Queue
                                             LastRound.Targets[skillType] = [.. targets];
                                             LastRound.ActionTypes.Add(skillType);
                                             LastRound.Effects[character] = skill;
+                                            if (_currentAction != null)
+                                            {
+                                                _currentAction.Skill = skill;
+                                                _currentAction.Targets.AddRange(targets);
+                                                _currentAction.DecisionPointsCost = costDP;
+                                            }
                                             if (skill is not CourageCommandSkill)
                                             {
                                                 _stats[statsCharacter].UseDecisionPoints += costDP;
@@ -1593,6 +1655,12 @@ namespace FunGame.Core.Model.Queue
                                             skill.CurrentCD = skill.RealCD;
                                             skill.Enable = false;
                                             LastRound.SkillsCost[skill] = $"{-cost:0.##} EP";
+                                            if (_currentAction != null)
+                                            {
+                                                _currentAction.Cost = $"{-cost:0.##} EP";
+                                                _currentAction.EPCost = cost;
+                                                _currentAction.SkillCD = skill.RealCD;
+                                            }
                                             WriteLine($"[ {character} ] 消耗了 {cost:0.##} 点能量，释放了{(skill.IsSuperSkill ? "爆发技" : "战技")} [ {skill.Name} ]！{(skill.Slogan != "" ? skill.Slogan : "")}");
 
                                             OnCharacterCastSkillEvent(character, dp, skillTarget, cost);
@@ -1662,6 +1730,11 @@ namespace FunGame.Core.Model.Queue
                                 LastRound.Targets[CharacterActionType.CastSkill] = [.. targets];
                                 LastRound.Skills[CharacterActionType.CastSkill] = skill;
                                 LastRound.ActionTypes.Add(CharacterActionType.CastSkill);
+                                if (_currentAction != null)
+                                {
+                                    _currentAction.Skill = skill;
+                                    _currentAction.Targets.AddRange(targets);
+                                }
                                 _castingSkills.Remove(character);
 
                                 skill.BeforeSkillCasted(character, targets, grids);
@@ -1671,6 +1744,12 @@ namespace FunGame.Core.Model.Queue
                                 skill.CurrentCD = skill.RealCD;
                                 skill.Enable = false;
                                 LastRound.SkillsCost[skill] = $"{-cost:0.##} MP";
+                                if (_currentAction != null)
+                                {
+                                    _currentAction.Cost = $"{-cost:0.##} MP";
+                                    _currentAction.MPCost = cost;
+                                    _currentAction.SkillCD = skill.RealCD;
+                                }
                                 WriteLine($"[ {character} ] 消耗了 {cost:0.##} 点魔法值，释放了魔法 [ {skill.Name} ]！{(skill.Slogan != "" ? skill.Slogan : "")}");
 
                                 OnCharacterCastSkillEvent(character, dp, skillTarget, cost);
@@ -1726,6 +1805,7 @@ namespace FunGame.Core.Model.Queue
                         Skill skill = _castingSuperSkills[character];
                         LastRound.Skills[CharacterActionType.CastSuperSkill] = skill;
                         LastRound.Effects[character] = skill;
+                        _currentAction?.Skill = skill;
                         _castingSuperSkills.Remove(character);
 
                         // 判断是否能够释放技能
@@ -1737,6 +1817,7 @@ namespace FunGame.Core.Model.Queue
                             // 免疫检定
                             CheckSkilledImmune(character, targets, skill);
                             LastRound.Targets[CharacterActionType.CastSuperSkill] = [.. targets];
+                            _currentAction?.Targets.AddRange(targets);
 
                             skill.BeforeSkillCasted(character, targets, grids);
 
@@ -1745,6 +1826,12 @@ namespace FunGame.Core.Model.Queue
                             skill.CurrentCD = skill.RealCD;
                             skill.Enable = false;
                             LastRound.SkillsCost[skill] = $"{-cost:0.##} EP";
+                            if (_currentAction != null)
+                            {
+                                _currentAction.Cost = $"{-cost:0.##} EP";
+                                _currentAction.EPCost = cost;
+                                _currentAction.SkillCD = skill.RealCD;
+                            }
                             WriteLine($"[ {character} ] 消耗了 {cost:0.##} 点能量值，释放了爆发技 [ {skill.Name} ]！{(skill.Slogan != "" ? skill.Slogan : "")}");
 
                             SkillTarget skillTarget = new(skill, targets, grids);
@@ -1768,7 +1855,10 @@ namespace FunGame.Core.Model.Queue
                         }
                         else
                         {
-                            WriteLine($"[ {character} ] 因能量不足放弃释放爆发技！");
+                            string failMsg = $"[ {character} ] 因能量不足放弃释放爆发技！";
+                            LastRound.OtherMessages.Add(failMsg);
+                            RecordCurrentActionFailure(failMsg);
+                            WriteLine(failMsg);
                             character.CharacterState = CharacterState.Actionable;
                             character.UpdateCharacterState();
                             // 放弃释放技能会获得3的硬直时间
@@ -1823,13 +1913,17 @@ namespace FunGame.Core.Model.Queue
                             int costDP = dp.GetActionPointCost(type);
                             if (dp.CurrentDecisionPoints < costDP)
                             {
-                                LastRound.OtherMessages.Add($"[ {character} ] 想要使用物品 [ {item.Name} ]，但决策点不足，无法使用物品！");
-                                if (IsDebug) WriteLine($"[ {character} ] 想要使用物品 [ {item.Name} ]，但决策点不足，无法使用物品！");
+                                string failMsg = $"[ {character} ] 想要使用物品 [ {item.Name} ]，但决策点不足，无法使用物品！";
+                                LastRound.OtherMessages.Add(failMsg);
+                                RecordCurrentActionFailure(failMsg);
+                                if (IsDebug) WriteLine(failMsg);
                             }
                             else if (!dp.CheckActionTypeQuota(CharacterActionType.UseItem))
                             {
-                                LastRound.OtherMessages.Add($"[ {character} ] 想要使用物品 [ {item.Name} ]，但该回合使用物品的次数已超过决策点配额，无法再使用物品！");
-                                if (IsDebug) WriteLine($"[ {character} ] 想要使用物品 [ {item.Name} ]，但该回合使用物品的次数已超过决策点配额，无法再使用物品！");
+                                string failMsg = $"[ {character} ] 想要使用物品 [ {item.Name} ]，但该回合使用物品的次数已超过决策点配额，无法再使用物品！";
+                                LastRound.OtherMessages.Add(failMsg);
+                                RecordCurrentActionFailure(failMsg);
+                                if (IsDebug) WriteLine(failMsg);
                             }
                             else if (UseItem(item, character, dp, enemys, teammates, castRange, allEnemys, allTeammates, aiDecision))
                             {
@@ -1839,6 +1933,11 @@ namespace FunGame.Core.Model.Queue
                                 dp.CurrentDecisionPoints -= costDP;
                                 LastRound.ActionTypes.Add(CharacterActionType.UseItem);
                                 LastRound.Items[CharacterActionType.UseItem] = item;
+                                if (_currentAction != null)
+                                {
+                                    _currentAction.Item = item;
+                                    _currentAction.DecisionPointsCost = costDP;
+                                }
                                 decided = true;
                                 baseTime += skill.RealHardnessTime > 0 ? skill.RealHardnessTime : 5;
                                 effects = [.. character.Effects.Where(e => e.IsInEffect).OrderByDescending(e => e.Priority)];
@@ -1900,6 +1999,12 @@ namespace FunGame.Core.Model.Queue
                 {
                     endTurn = true;
                 }
+
+                // 操作结算完成，即时外发单次操作记录
+                if (_currentAction != null)
+                {
+                    RoundRecordSink?.SendAction(_currentAction.Snapshot());
+                }
             }
 
             if (character.CharacterState != CharacterState.Casting && dp.ActionsHardnessTime.Count > 0)
@@ -1918,11 +2023,13 @@ namespace FunGame.Core.Model.Queue
             {
                 newHardnessTime = Calculation.Round2Digits(baseTime);
                 LastRound.HardnessTime = newHardnessTime;
+                _currentAction?.HardnessTime = newHardnessTime;
             }
             else
             {
                 newHardnessTime = Calculation.Round2Digits(baseTime);
                 LastRound.CastTime = newHardnessTime;
+                _currentAction?.CastTime = newHardnessTime;
             }
 
             AfterCharacterDecision(character, dp);
@@ -1936,6 +2043,15 @@ namespace FunGame.Core.Model.Queue
             // 统一在回合结束时处理角色的死亡
             ProcessCharacterDeath();
 
+            // 记录回合结束时间，状态推算的时间轴基准
+            LastRound.TotalTime = TotalTime;
+
+            // 周期性生成状态检查点：死亡结算后，状态为最新；gameEnd 也会生成
+            if (CheckpointInterval > 0 && TotalRound % CheckpointInterval == 0)
+            {
+                LastRound.Checkpoint = CreateStateCheckpoint();
+            }
+
             // 移除回合奖励
             RemoveRoundRewards(character, rewards);
 
@@ -1947,6 +2063,9 @@ namespace FunGame.Core.Model.Queue
                 AfterTurn(character);
 
                 _isInRound = false;
+                _currentAction = null;
+                // 游戏结束时也外发最终回合记录，含死亡结算数据
+                RoundRecordSink?.SendRound(LastRound.Snapshot());
                 return _isGameEnd;
             }
 
@@ -1961,6 +2080,9 @@ namespace FunGame.Core.Model.Queue
             }
             AddCharacter(character, newHardnessTime, isCheckProtected);
             OnQueueUpdatedEvent(_queue, character, dp, newHardnessTime, QueueUpdatedReason.Action, "设置角色行动后的硬直时间。");
+
+            // 回合结算完成（含死亡/连杀/复活/硬直），即时外发回合记录
+            RoundRecordSink?.SendRound(LastRound.Snapshot());
 
             effects = [.. character.Effects.OrderByDescending(e => e.Priority)];
             foreach (Effect effect in effects)
@@ -2001,6 +2123,7 @@ namespace FunGame.Core.Model.Queue
 
             WriteLine("");
             _isInRound = false;
+            _currentAction = null;
 
             // 有人想要插队吗？
             WillPreCastSuperSkill();
@@ -2025,6 +2148,68 @@ namespace FunGame.Core.Model.Queue
                 }
             }
             _roundDeaths.Clear();
+        }
+
+        /// <summary>
+        /// 将当前操作标记为失败并记录失败原因
+        /// </summary>
+        /// <param name="failMsg">失败原因文本</param>
+        private void RecordCurrentActionFailure(string failMsg)
+        {
+            if (_currentAction != null)
+            {
+                _currentAction.IsSuccess = false;
+                _currentAction.FailReason = failMsg;
+                _currentAction.Messages.Add(failMsg);
+            }
+        }
+
+        /// <summary>
+        /// 生成全角色状态检查点（每个角色一条状态快照，含 HP/MP/EP、装备栏、技能状态、状态栏特效）
+        /// </summary>
+        /// <returns></returns>
+        protected List<CharacterStateSnapshot> CreateStateCheckpoint()
+        {
+            List<CharacterStateSnapshot> snapshots = [];
+            List<Character> characters = [.. _allCharacters.Union(_queue).Distinct()];
+            foreach (Character character in characters)
+            {
+                CharacterStateSnapshot state = new()
+                {
+                    Character = character,
+                    HP = character.HP,
+                    MaxHP = character.MaxHP,
+                    MP = character.MP,
+                    MaxMP = character.MaxMP,
+                    EP = character.EP,
+                    HR = character.HR,
+                    MR = character.MR
+                };
+
+                // 装备栏（物品 ID）
+                EquipSlot slot = character.EquipSlot;
+                if (slot.Weapon != null) state.Equipments[EquipSlotType.Weapon] = slot.Weapon.Id;
+                if (slot.Armor != null) state.Equipments[EquipSlotType.Armor] = slot.Armor.Id;
+                if (slot.Shoes != null) state.Equipments[EquipSlotType.Shoes] = slot.Shoes.Id;
+                if (slot.Accessory1 != null) state.Equipments[EquipSlotType.Accessory1] = slot.Accessory1.Id;
+                if (slot.Accessory2 != null) state.Equipments[EquipSlotType.Accessory2] = slot.Accessory2.Id;
+                if (slot.MagicCardPack != null) state.Equipments[EquipSlotType.MagicCardPack] = slot.MagicCardPack.Id;
+
+                // 技能状态
+                foreach (Skill skill in character.Skills)
+                {
+                    state.Skills.Add(new SkillStateSnapshot { SkillId = skill.Id, SkillName = skill.Name, Level = skill.Level, CurrentCD = skill.CurrentCD });
+                }
+
+                // 状态栏特效
+                foreach (Effect effect in character.Effects.Where(e => e.ShowInStatusBar && e.IsInEffect))
+                {
+                    state.Effects.Add(new EffectStateSnapshot { EffectId = effect.Id, EffectName = effect.Name, EffectType = effect.EffectType, RemainDuration = effect.RemainDuration, RemainDurationTurn = effect.RemainDurationTurn });
+                }
+
+                snapshots.Add(state);
+            }
+            return snapshots;
         }
 
         /// <summary>
@@ -2155,6 +2340,10 @@ namespace FunGame.Core.Model.Queue
                 // 暴击了修改目标对应的值为 true
                 LastRound.IsCritical[enemy] = true;
             }
+            if (_currentAction != null && !_currentAction.IsCritical.TryAdd(enemy, damageResult == DamageResult.Critical) && damageResult == DamageResult.Critical)
+            {
+                _currentAction.IsCritical[enemy] = true;
+            }
 
             List<Character> characters = [actor, enemy];
             bool isEvaded = damageResult == DamageResult.Evaded;
@@ -2251,6 +2440,7 @@ namespace FunGame.Core.Model.Queue
                         // 免疫
                         damageResult = DamageResult.Immune;
                         LastRound.IsImmune[enemy] = true;
+                        _currentAction?.IsImmune[enemy] = true;
                         WriteLine($"[ {enemy} ] 免疫了此伤害！");
                         actualDamage = 0;
                     }
@@ -2532,6 +2722,7 @@ namespace FunGame.Core.Model.Queue
             else
             {
                 LastRound.IsEvaded[enemy] = true;
+                _currentAction?.IsEvaded[enemy] = true;
                 actualDamage = 0;
             }
 
@@ -2866,6 +3057,10 @@ namespace FunGame.Core.Model.Queue
                 {
                     LastRound.Heals[target] += heal;
                 }
+                if (_currentAction != null && !_currentAction.Heals.TryAdd(target, heal))
+                {
+                    _currentAction.Heals[target] += heal;
+                }
             }
 
             if (heal <= 0 || heal.ToString("0.##") == "0")
@@ -3115,6 +3310,11 @@ namespace FunGame.Core.Model.Queue
                     if (targets.Count > 0 && CheckCanCast(character, skill, out double cost))
                     {
                         LastRound.Targets[CharacterActionType.UseItem] = [.. targets];
+                        if (_currentAction != null)
+                        {
+                            _currentAction.Skill = skill;
+                            _currentAction.Targets.AddRange(targets);
+                        }
 
                         WriteLine($"[ {character} ] 使用了物品 [ {item.Name} ]！");
                         item.ReduceTimesAndRemove();
@@ -3142,6 +3342,11 @@ namespace FunGame.Core.Model.Queue
                         {
                             character.MP -= costMP;
                             LastRound.ItemsCost[item] = $"{-costMP:0.##} MP";
+                            if (_currentAction != null)
+                            {
+                                _currentAction.Cost = $"{-costMP:0.##} MP";
+                                _currentAction.MPCost = costMP;
+                            }
                             line += $"消耗了 {costMP:0.##} 点魔法值，";
                         }
 
@@ -3150,6 +3355,11 @@ namespace FunGame.Core.Model.Queue
                             character.EP -= costEP;
                             if (LastRound.ItemsCost[item] != "") LastRound.ItemsCost[item] += " / ";
                             LastRound.ItemsCost[item] += $"{-costEP:0.##} EP";
+                            if (_currentAction != null)
+                            {
+                                _currentAction.Cost += (_currentAction.Cost != "" ? " / " : "") + $"{-costEP:0.##} EP";
+                                _currentAction.EPCost = costEP;
+                            }
                             line += $"消耗了 {costEP:0.##} 点能量，";
                         }
 
@@ -4537,6 +4747,17 @@ namespace FunGame.Core.Model.Queue
             else
             {
                 LastRound.Damages[characterTaken] = damage;
+            }
+            if (_currentAction != null)
+            {
+                if (_currentAction.Damages.TryGetValue(characterTaken, out double actionDamage))
+                {
+                    _currentAction.Damages[characterTaken] = actionDamage + damage;
+                }
+                else
+                {
+                    _currentAction.Damages[characterTaken] = damage;
+                }
             }
         }
 

--- a/Model/Queue/GamingQueue.cs
+++ b/Model/Queue/GamingQueue.cs
@@ -705,8 +705,9 @@ namespace FunGame.Core.Model.Queue
             {
                 // 进入下一回合
                 TotalRound++;
+                // 将上一回合记录以结构快照的形式归档，防止后续写入（例如时间流逝中的复活结算）污染已归档的历史记录
+                if (TotalRound > 1) Rounds.Add(LastRound.Snapshot());
                 LastRound = new(TotalRound) { Actor = character };
-                Rounds.Add(LastRound);
 
                 if (TotalRound == 1)
                 {
@@ -1911,6 +1912,19 @@ namespace FunGame.Core.Model.Queue
                 _stats[character].ActionTurn += 1;
             }
 
+            // 提前结算硬直时间，使决策完成事件快照包含本回合的硬直/吟唱数据
+            double newHardnessTime = baseTime;
+            if (character.CharacterState != CharacterState.Casting)
+            {
+                newHardnessTime = Calculation.Round2Digits(baseTime);
+                LastRound.HardnessTime = newHardnessTime;
+            }
+            else
+            {
+                newHardnessTime = Calculation.Round2Digits(baseTime);
+                LastRound.CastTime = newHardnessTime;
+            }
+
             AfterCharacterDecision(character, dp);
             OnCharacterDecisionCompletedEvent(character, dp, LastRound.Snapshot());
             effects = [.. character.Effects.Where(e => e.IsInEffect).OrderByDescending(e => e.Priority)];
@@ -1937,20 +1951,15 @@ namespace FunGame.Core.Model.Queue
             }
 
             // 减少硬直时间
-            double newHardnessTime = baseTime;
             if (character.CharacterState != CharacterState.Casting)
             {
-                newHardnessTime = Calculation.Round2Digits(baseTime);
                 WriteLine($"[ {character} ] 回合结束，获得硬直时间：{newHardnessTime} {GameplayEquilibriumConstant.InGameTime}");
             }
             else
             {
-                newHardnessTime = Calculation.Round2Digits(baseTime);
                 WriteLine($"[ {character} ] 进行吟唱，持续时间：{newHardnessTime} {GameplayEquilibriumConstant.InGameTime}");
-                LastRound.CastTime = newHardnessTime;
             }
             AddCharacter(character, newHardnessTime, isCheckProtected);
-            LastRound.HardnessTime = newHardnessTime;
             OnQueueUpdatedEvent(_queue, character, dp, newHardnessTime, QueueUpdatedReason.Action, "设置角色行动后的硬直时间。");
 
             effects = [.. character.Effects.OrderByDescending(e => e.Priority)];

--- a/Model/Queue/GamingQueue.cs
+++ b/Model/Queue/GamingQueue.cs
@@ -1642,6 +1642,7 @@ namespace FunGame.Core.Model.Queue
                                             LastRound.Effects[character] = skill;
                                             if (_currentAction != null)
                                             {
+                                                _currentAction.ActionType = skillType;
                                                 _currentAction.Skill = skill;
                                                 _currentAction.Targets.AddRange(targets);
                                                 _currentAction.DecisionPointsCost = costDP;

--- a/Model/Queue/MixGamingQueue.cs
+++ b/Model/Queue/MixGamingQueue.cs
@@ -1,5 +1,6 @@
 ﻿using FunGame.Core.Entity;
 using FunGame.Core.Library.Constant;
+using FunGame.Core.Model.Framework;
 
 namespace FunGame.Core.Model.Queue
 {
@@ -92,14 +93,31 @@ namespace FunGame.Core.Model.Queue
             int top = 1;
             WriteLine("");
             WriteLine("=== 排名 ===");
+            LastRound.GameResult.Clear();
             for (int i = _eliminated.Count - 1; i >= 0; i--)
             {
                 Character ec = _eliminated[i];
                 CharacterStatistics statistics = CharacterStatistics[ec];
+                _earnedMoney.TryGetValue(ec, out int earned);
+                _maxContinuousKilling.TryGetValue(ec, out int kills);
+                // 结构化排名条目（引用 + 统计，按名次顺序；消费端可定制渲染）
+                LastRound.GameResult.Add(new RankingEntry
+                {
+                    Rank = top,
+                    IsWinner = ec == winner,
+                    IsTeam = false,
+                    Character = ec,
+                    Kills = statistics.Kills,
+                    Deaths = statistics.Deaths,
+                    Assists = statistics.Assists,
+                    FirstKills = statistics.FirstKills,
+                    TotalEarnedMoney = earned,
+                    MaxContinuousKilling = kills
+                });
                 string topCharacter = ec.ToString() +
                     (statistics.FirstKills > 0 ? " [ 第一滴血 ]" : "") +
-                    (_maxContinuousKilling.TryGetValue(ec, out int kills) && kills > 1 ? $" [ {CharacterSet.GetContinuousKilling(kills)} ]" : "") +
-                    (_earnedMoney.TryGetValue(ec, out int earned) ? $" [ 已赚取 {earned} {GameplayEquilibriumConstant.InGameCurrency} ]" : "");
+                    (kills > 1 ? $" [ {CharacterSet.GetContinuousKilling(kills)} ]" : "") +
+                    (earned > 0 ? $" [ 已赚取 {earned} {GameplayEquilibriumConstant.InGameCurrency} ]" : "");
                 if (top == 1)
                 {
                     WriteLine("冠军：" + topCharacter);

--- a/Model/Queue/TeamGamingQueue.cs
+++ b/Model/Queue/TeamGamingQueue.cs
@@ -59,6 +59,11 @@ namespace FunGame.Core.Model.Queue
         }
 
         /// <summary>
+        /// 返回角色所属队伍名（用于回合记录的角色队伍归属标记）
+        /// </summary>
+        protected override string? GetCharacterTeamName(Character character) => GetTeam(character)?.Name;
+
+        /// <summary>
         /// 从已淘汰的团队中获取角色的团队
         /// </summary>
         /// <param name="character"></param>
@@ -241,6 +246,7 @@ namespace FunGame.Core.Model.Queue
             WriteLine("");
             WriteLine("=== 排名 ===");
             WriteLine("");
+            LastRound.GameResult.Clear();
 
             _eliminatedTeams.Add(winner);
             _teams.Remove(winner.Name);
@@ -248,6 +254,31 @@ namespace FunGame.Core.Model.Queue
             for (int i = _eliminatedTeams.Count - 1; i >= 0; i--)
             {
                 Team team = _eliminatedTeams[i];
+                int teamKills = 0;
+                int teamDeaths = 0;
+                int teamAssists = 0;
+                int teamEarned = 0;
+                foreach (Character ec in team.Members)
+                {
+                    CharacterStatistics statistics = CharacterStatistics[ec];
+                    teamKills += statistics.Kills;
+                    teamDeaths += statistics.Deaths;
+                    teamAssists += statistics.Assists;
+                    teamEarned += _earnedMoney.TryGetValue(ec, out int earned) ? earned : 0;
+                }
+                // 结构化排名条目（团队引用 + 聚合统计，按名次顺序；消费端可定制渲染）
+                LastRound.GameResult.Add(new RankingEntry
+                {
+                    Rank = top,
+                    IsWinner = team == winner,
+                    IsTeam = true,
+                    Team = team,
+                    Kills = teamKills,
+                    Deaths = teamDeaths,
+                    Assists = teamAssists,
+                    TotalEarnedMoney = teamEarned,
+                    Score = team.Score
+                });
                 string topTeam = "";
                 if (top == 1)
                 {


### PR DESCRIPTION
**PR #160（回合记录的结构快照改进）相对 master 的主要更改与设计目标总结**

### 设计目标
1. **减小记录体积**：原先每回合完整状态快照会导致输出文件过大，不适合长期存储或网络传输。
2. **支持高效回放/观战**：在不重跑游戏引擎的前提下，能准确还原任意回合结束时角色的状态（HP/MP/EP、装备、技能冷却、特效等）。
3. **引入操作级事件流**：记录细粒度操作（伤害、治疗、消耗、施加特效等），配合定期检查点，实现“检查点 + 事件流推算”的确定性预测。
4. **便于复盘与展示**：提供纯数据驱动的文本渲染器，供客户端/观战端直接使用。

### 主要更改内容

**1. 新增核心预测与渲染组件**
- `BattleStatePredictor`：基于“最近检查点 + 操作事件流 + 时间轴（TotalTime）”推算指定回合结束时所有（或单个）角色的状态。支持自动回复、冷却递减、特效剩余时间、伤害/治疗应用、复活等，并容忍特效钩子带来的小误差（下个检查点自动校正）。
- `RoundRecordRenderer`：纯读取记录生成回合文本（操作流 + 汇总信息），不依赖引擎重跑，适合复盘和观战。

**2. 数据模型重构**
- 新增 `ActionRecord`：记录单次操作的详细信息（行动者、MP/EP 消耗、伤害/治疗字典、施加的特效、技能冷却等）。
- 新增 `CharacterStateSnapshot`（含技能状态、特效状态子结构）：精简的角色状态快照，用于检查点。
- `RoundRecord` 升级：增加操作列表（`Actions`）、可选检查点（`Checkpoint`）、时间轴等字段，支持按顺序回放。

**3. 序列化与接口支持**
- 新增/更新多个 JSON 转换器（`ActionRecordConverter`、`CharacterStateSnapshotConverter`、`RoundRecordConverter` 等）。
- 新增 `IRoundRecordSink` 接口，更新 `IGamingQueue`。
- 集成到 `GamingQueue`、`MixGamingQueue`、`TeamGamingQueue` 以及相关实体（Character、Skill、Effect、Item）。

**4. 实现路径（按提交）**
- 第一阶段：结构快照改进（引入检查点思路）。
- 第二阶段：添加操作级记录。
- 第三阶段：完成按顺序的操作级回放记录支持。
- 第四阶段：添加角色数据统计输出并优化渲染格式。

### 核心设计思路
采用 **定期状态检查点 + 操作事件流** 的混合方案：
- 只在关键节点保存完整快照。
- 中间用轻量操作记录驱动状态推算。
- 既控制了文件大小，又保证了回放精度和可扩展性。

整体上，这是一次面向“可存储、可回放、可观战”的回合日志系统重构，显著提升了记录的实用性和效率。目前，输出一场2000回合的回合日志，压缩为zip不到1MB，解压后15MB左右，已经足够轻量化。