### PR TITLE
实现即时主动POST外发数据包

### DIFF
--- a/Api/DefaultRoundRecordSink.cs
+++ b/Api/DefaultRoundRecordSink.cs
@@ -1,0 +1,382 @@
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using FunGame.Core.Entity;
+using FunGame.Core.Interface.Base;
+using FunGame.Core.Model.Framework;
+
+namespace FunGame.Core.Api
+{
+    /// <summary>
+    /// 即时外发事件 id（<see cref="RoundRecordPayload.E"/> 的取值）
+    /// </summary>
+    public static class RoundRecordSinkEventIds
+    {
+        /// <summary>
+        /// "0" ActionRecord：当前角色触发的操作（每次角色操作结束后发送）
+        /// </summary>
+        public const string Action = "0";
+
+        /// <summary>
+        /// "1" RoundRecord：当前回合的数据（每次角色操作结束后发送）
+        /// </summary>
+        public const string Round = "1";
+
+        /// <summary>
+        /// "2" RoundRecord：当前回合的数据，相比事件 "1" 内容更多（在回合结束时，且当前回合为检查点时才会发送）
+        /// </summary>
+        public const string CheckpointRound = "2";
+
+        /// <summary>
+        /// "3" CharacterStatistics：包含现阶段所有角色的统计数据（在回合结束时发送）
+        /// </summary>
+        public const string CharacterStatistics = "3";
+
+        /// <summary>
+        /// "4" Character[]：所有角色的完整数据（在回合结束时发送）
+        /// </summary>
+        public const string Characters = "4";
+
+        /// <summary>
+        /// "5" Team[]：团队的完整数据（在回合结束时发送）
+        /// </summary>
+        public const string Teams = "5";
+
+        /// <summary>
+        /// "6" Dictionary&lt;string, double&gt;：行动顺序表的数据（每次角色操作结束后发送），key: string=角色的Guid，value: double=当前等待时间
+        /// </summary>
+        public const string QueueData = "6";
+
+        /// <summary>
+        /// "7" string[]：已淘汰/处于死亡的角色名单（每次角色操作结束后发送），value: string=角色的Guid
+        /// </summary>
+        public const string EliminatedCharacters = "7";
+
+        /// <summary>
+        /// "8" string[]：已淘汰的团队名单（每次角色操作结束后发送），value: string=团队的Name
+        /// </summary>
+        public const string EliminatedTeams = "8";
+
+        /// <summary>
+        /// "13" string：验证签名事件
+        /// </summary>
+        public const string VerifySignature = "13";
+    }
+
+    /// <summary>
+    /// 即时主动 POST 外发数据包的默认实现<para/>
+    /// 将游戏过程中产生的数据包即时 POST 到外部专用服务器，服务器需存在一个 POST 方法且 body 接收与 <see cref="RoundRecordPayload"/> 相同格式的模型<para/>
+    /// 若设置了 <see cref="Secret"/>，则在 <see cref="Attach"/> 后立即发送事件 "13" 验证签名，成功前其他事件不会外发，且每隔 <see cref="HandshakeRetryIntervalSeconds"/> 秒重发一次
+    /// </summary>
+    public class DefaultRoundRecordSink : IRoundRecordSink, IDisposable
+    {
+        /// <summary>
+        /// 服务器的 accessToken（Bearer 认证），默认为空
+        /// </summary>
+        public string AccessToken { get; set; } = "";
+
+        /// <summary>
+        /// 用于验证签名的 secret，默认为空（为空时不做签名验证，直接外发；已在实例化后赋值时立即发起签名验证）
+        /// </summary>
+        public string Secret
+        {
+            get => _secret;
+            set
+            {
+                _secret = value;
+                if (_queueId != Guid.Empty && !string.IsNullOrEmpty(value))
+                {
+                    BeginHandshake();
+                }
+            }
+        }
+
+        /// <summary>
+        /// 签名验证失败后重发事件 "13" 的间隔（秒），默认 60 秒，直到游戏结束
+        /// </summary>
+        public int HandshakeRetryIntervalSeconds { get; set; } = 60;
+
+        /// <summary>
+        /// 可访问 POST 方法的 URL
+        /// </summary>
+        private readonly string _url;
+
+        /// <summary>
+        /// 会外发什么事件（事件 id，见 <see cref="RoundRecordSinkEventIds"/>）
+        /// </summary>
+        private readonly HashSet<string> _intents;
+
+        /// <summary>
+        /// 用于外发的 HttpClient（所有 POST 请求必须在 5 秒内返回结果，否则挂起多个请求会影响游戏性能）
+        /// </summary>
+        private readonly HttpClient _client;
+
+        /// <summary>
+        /// 外发数据包的序列化选项（与 <see cref="JsonService.GeneralOptions"/> 一致，但不缩进）
+        /// </summary>
+        private readonly JsonSerializerOptions _serializerOptions;
+
+        /// <summary>
+        /// 用于验证签名的 secret
+        /// </summary>
+        private string _secret = "";
+
+        /// <summary>
+        /// 同步锁
+        /// </summary>
+        private readonly Lock _lock = new();
+
+        /// <summary>
+        /// 所属 GamingQueue 的 Guid
+        /// </summary>
+        private Guid _queueId = Guid.Empty;
+
+        /// <summary>
+        /// 握手成功后的签名（null 表示未握手成功）
+        /// </summary>
+        private string? _signature = null;
+
+        /// <summary>
+        /// 签名验证重试定时器
+        /// </summary>
+        private Timer? _handshakeTimer = null;
+
+        /// <summary>
+        /// 是否正在发送签名验证请求（防止定时器重入）
+        /// </summary>
+        private int _handshaking = 0;
+
+        /// <summary>
+        /// 是否已释放
+        /// </summary>
+        private bool _disposed = false;
+
+        /// <summary>
+        /// 新建一个即时主动 POST 外发数据包实现
+        /// </summary>
+        /// <param name="url">可访问 POST 方法的 URL</param>
+        /// <param name="intents">会外发什么事件（事件 id，见 <see cref="RoundRecordSinkEventIds"/>）</param>
+        public DefaultRoundRecordSink(string url, string[] intents)
+        {
+            _url = url ?? throw new ArgumentNullException(nameof(url));
+            _intents = [.. intents ?? []];
+            _client = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(5)
+            };
+            _serializerOptions = new JsonSerializerOptions(JsonService.GeneralOptions)
+            {
+                WriteIndented = false
+            };
+        }
+
+        /// <summary>
+        /// 绑定所属队列（GamingQueue 设置 <see cref="Model.Queue.GamingQueue.RoundRecordSink"/> 属性时调用）
+        /// </summary>
+        /// <param name="queueId">所属 GamingQueue 的 Guid</param>
+        public void Attach(Guid queueId)
+        {
+            _queueId = queueId;
+            if (!string.IsNullOrEmpty(Secret))
+            {
+                BeginHandshake();
+            }
+        }
+
+        /// <summary>
+        /// 游戏结束通知（停止签名验证重试）
+        /// </summary>
+        public void End()
+        {
+            lock (_lock)
+            {
+                _handshakeTimer?.Dispose();
+                _handshakeTimer = null;
+            }
+        }
+
+        /// <summary>
+        /// 外发单次操作记录
+        /// </summary>
+        public void SendAction(ActionRecord action) => TrySend(RoundRecordSinkEventIds.Action, action);
+
+        /// <summary>
+        /// 外发当前回合数据
+        /// </summary>
+        public void SendRound(RoundRecord round) => TrySend(RoundRecordSinkEventIds.Round, round);
+
+        /// <summary>
+        /// 外发检查点回合记录
+        /// </summary>
+        public void SendCheckpointRound(RoundRecord round) => TrySend(RoundRecordSinkEventIds.CheckpointRound, round);
+
+        /// <summary>
+        /// 外发现阶段所有角色的统计数据
+        /// </summary>
+        public void SendCharacterStatistics(Dictionary<Guid, CharacterStatistics> statistics) => TrySend(RoundRecordSinkEventIds.CharacterStatistics, statistics);
+
+        /// <summary>
+        /// 外发所有角色的完整数据
+        /// </summary>
+        public void SendCharacters(IEnumerable<Character> characters) => TrySend(RoundRecordSinkEventIds.Characters, characters);
+
+        /// <summary>
+        /// 外发团队的完整数据
+        /// </summary>
+        public void SendTeams(IEnumerable<Team> teams) => TrySend(RoundRecordSinkEventIds.Teams, teams);
+
+        /// <summary>
+        /// 外发行动顺序表的数据
+        /// </summary>
+        public void SendQueueData(Dictionary<Guid, double> queueData) => TrySend(RoundRecordSinkEventIds.QueueData, queueData);
+
+        /// <summary>
+        /// 外发已淘汰/处于死亡的角色名单
+        /// </summary>
+        public void SendEliminatedCharacters(IEnumerable<string> characterGuids) => TrySend(RoundRecordSinkEventIds.EliminatedCharacters, characterGuids);
+
+        /// <summary>
+        /// 外发已淘汰的团队名单
+        /// </summary>
+        public void SendEliminatedTeams(IEnumerable<string> teamNames) => TrySend(RoundRecordSinkEventIds.EliminatedTeams, teamNames);
+
+        /// <summary>
+        /// 释放资源
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            End();
+            _client.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// 开始签名验证（立即发送事件 "13"，失败则每隔 <see cref="HandshakeRetryIntervalSeconds"/> 秒重发一次，直到成功或游戏结束）
+        /// </summary>
+        private void BeginHandshake()
+        {
+            lock (_lock)
+            {
+                _signature = null;
+                _handshakeTimer?.Dispose();
+                _handshakeTimer = new Timer(_ => _ = TryHandshakeAsync(), null, TimeSpan.Zero, TimeSpan.FromSeconds(Math.Max(1, HandshakeRetryIntervalSeconds)));
+            }
+        }
+
+        /// <summary>
+        /// 发送签名验证请求（事件 "13"）并确认检验结果
+        /// </summary>
+        private async Task TryHandshakeAsync()
+        {
+            if (Interlocked.CompareExchange(ref _handshaking, 1, 0) != 0)
+            {
+                return;
+            }
+            try
+            {
+                long t = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                // d 属性：secret 的 SHA256 哈希值，此时 s 属性为空字符串
+                string d = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(Secret)));
+                RoundRecordPayload payload = new()
+                {
+                    G = _queueId,
+                    T = t,
+                    E = RoundRecordSinkEventIds.VerifySignature,
+                    D = d,
+                    S = ""
+                };
+                string json = JsonSerializer.Serialize(payload, _serializerOptions);
+                using HttpResponseMessage? response = await PostAsync(json).ConfigureAwait(false);
+                if (response == null || !response.IsSuccessStatusCode)
+                {
+                    return;
+                }
+                // 服务器返回的哈希：用 HMAC-SHA512 算法，将 d 属性值的前 10、后 10 个字符相连接，
+                // 并在所得字符串后面补充 t 属性的值作为 key，计算原始 secret 的哈希值
+                string key = d[..10] + d[^10..] + t;
+                string expected = Convert.ToHexStringLower(HMACSHA512.HashData(Encoding.UTF8.GetBytes(key), Encoding.UTF8.GetBytes(Secret)));
+                string? actual = (await response.Content.ReadAsStringAsync().ConfigureAwait(false))?.Trim();
+                if (string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase))
+                {
+                    lock (_lock)
+                    {
+                        // 握手成功，后续 POST 请求的 s 属性都会携带这个哈希值
+                        _signature = expected;
+                        _handshakeTimer?.Dispose();
+                        _handshakeTimer = null;
+                    }
+                }
+                // 不成功：等下一个周期重发事件 "13"
+            }
+            catch
+            {
+                // 服务器临时不可达：等下一个周期重发事件 "13"
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _handshaking, 0);
+            }
+        }
+
+        /// <summary>
+        /// 尝试外发一个事件（intents 不包含该事件，或设置了 secret 但签名验证尚未成功时直接丢弃）
+        /// </summary>
+        private void TrySend(string e, object? d)
+        {
+            if (!_intents.Contains(e))
+            {
+                return;
+            }
+            if (!string.IsNullOrEmpty(Secret) && _signature == null)
+            {
+                // 签名验证成功之前，其他所有的事件都不会外发
+                return;
+            }
+            try
+            {
+                RoundRecordPayload payload = new()
+                {
+                    G = _queueId,
+                    T = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    E = e,
+                    D = d,
+                    S = _signature ?? ""
+                };
+                string json = JsonSerializer.Serialize(payload, _serializerOptions);
+                _ = PostAsync(json);
+            }
+            catch
+            {
+                // 序列化失败：丢弃，不补发
+            }
+        }
+
+        /// <summary>
+        /// 异步 POST 外发数据包（不阻塞游戏线程；网络异常时返回 null，错过的消息不会补发）
+        /// </summary>
+        private async Task<HttpResponseMessage?> PostAsync(string json)
+        {
+            try
+            {
+                using HttpRequestMessage request = new(HttpMethod.Post, _url);
+                request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+                if (!string.IsNullOrEmpty(AccessToken))
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+                }
+                return await _client.SendAsync(request).ConfigureAwait(false);
+            }
+            catch
+            {
+                // 发送失败：丢弃，不补发
+                return null;
+            }
+        }
+    }
+}

--- a/Interface/Base/IRoundRecordSink.cs
+++ b/Interface/Base/IRoundRecordSink.cs
@@ -1,23 +1,80 @@
+using FunGame.Core.Entity;
 using FunGame.Core.Model.Framework;
 
 namespace FunGame.Core.Interface.Base
 {
     /// <summary>
     /// 回合记录外发通道<para/>
-    /// 实现方负责将记录序列化并发送（如 POST 到远程服务、写入消息队列等）
+    /// 实现方负责将记录序列化并发送（如 POST 到远程服务、写入消息队列等）<para/>
+    /// 事件 id 与方法的对应关系："0" <see cref="SendAction"/>、"1" <see cref="SendRound"/>、"2" <see cref="SendCheckpointRound"/>、
+    /// "3" <see cref="SendCharacterStatistics"/>、"4" <see cref="SendCharacters"/>、"5" <see cref="SendTeams"/>、
+    /// "6" <see cref="SendQueueData"/>、"7" <see cref="SendEliminatedCharacters"/>、"8" <see cref="SendEliminatedTeams"/>
     /// </summary>
     public interface IRoundRecordSink
     {
         /// <summary>
-        /// 外发单次操作记录（操作完成后即时调用，用于实时增量推送）
+        /// 绑定所属队列（GamingQueue 设置 <see cref="Model.Queue.GamingQueue.RoundRecordSink"/> 属性时调用，提供队列 Guid；自定义协议实现可忽略）
+        /// </summary>
+        /// <param name="queueId">所属 GamingQueue 的 Guid</param>
+        void Attach(Guid queueId);
+
+        /// <summary>
+        /// 游戏结束通知（停止握手重试等；自定义协议实现可忽略）
+        /// </summary>
+        void End();
+
+        /// <summary>
+        /// 外发单次操作记录（每次角色操作完成后即时调用，用于实时增量推送）
         /// </summary>
         /// <param name="action">操作记录（结构快照，实体引用共享）</param>
         void SendAction(ActionRecord action);
 
         /// <summary>
-        /// 外发回合记录（回合决策完成后调用，包含本回合操作流与回合汇总）
+        /// 外发当前回合数据（每次角色操作完成后即时调用，包含本回合已发生的操作流与汇总）
         /// </summary>
         /// <param name="round">回合记录（结构快照，实体引用共享）</param>
         void SendRound(RoundRecord round);
+
+        /// <summary>
+        /// 外发检查点回合记录（回合结束时且当前回合为检查点时调用，相比 <see cref="SendRound"/> 内容更多，附带全角色状态快照）
+        /// </summary>
+        /// <param name="round">回合记录（结构快照，实体引用共享）</param>
+        void SendCheckpointRound(RoundRecord round);
+
+        /// <summary>
+        /// 外发现阶段所有角色的统计数据（回合结束时调用）
+        /// </summary>
+        /// <param name="statistics">角色 Guid -> 统计数据</param>
+        void SendCharacterStatistics(Dictionary<Guid, CharacterStatistics> statistics);
+
+        /// <summary>
+        /// 外发所有角色的完整数据（回合结束时调用）
+        /// </summary>
+        /// <param name="characters">参与本次游戏的所有角色</param>
+        void SendCharacters(IEnumerable<Character> characters);
+
+        /// <summary>
+        /// 外发团队的完整数据（回合结束时调用；非团队模式为空）
+        /// </summary>
+        /// <param name="teams">当前存活的团队</param>
+        void SendTeams(IEnumerable<Team> teams);
+
+        /// <summary>
+        /// 外发行动顺序表的数据（每次角色操作完成后即时调用）
+        /// </summary>
+        /// <param name="queueData">角色 Guid -> 当前等待时间</param>
+        void SendQueueData(Dictionary<Guid, double> queueData);
+
+        /// <summary>
+        /// 外发已淘汰/处于死亡的角色名单（每次角色操作完成后即时调用）
+        /// </summary>
+        /// <param name="characterGuids">角色的 Guid</param>
+        void SendEliminatedCharacters(IEnumerable<string> characterGuids);
+
+        /// <summary>
+        /// 外发已淘汰的团队名单（回合结束时调用；非团队模式为空）
+        /// </summary>
+        /// <param name="teamNames">团队的 Name</param>
+        void SendEliminatedTeams(IEnumerable<string> teamNames);
     }
 }

--- a/Model/Framework/RoundRecordPayload.cs
+++ b/Model/Framework/RoundRecordPayload.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Serialization;
+
+namespace FunGame.Core.Model.Framework
+{
+    /// <summary>
+    /// 即时外发数据包（RoundRecordPayload，POST 到外部专用服务器的线协议模型）<para/>
+    /// 序列化字段为紧凑格式：g（GamingQueue 的 Guid）、t（当前时间戳）、e（事件 id）、d（数据包）、s（签名）
+    /// </summary>
+    public class RoundRecordPayload
+    {
+        /// <summary>
+        /// GamingQueue 的 Guid
+        /// </summary>
+        [JsonPropertyName("g")]
+        public Guid G { get; set; } = Guid.Empty;
+
+        /// <summary>
+        /// 当前时间戳（Unix 毫秒）
+        /// </summary>
+        [JsonPropertyName("t")]
+        public long T { get; set; } = 0;
+
+        /// <summary>
+        /// POST 事件（事件 id，如 "0"、"1"、"13"，见 <see cref="Api.RoundRecordSinkEventIds"/>）
+        /// </summary>
+        [JsonPropertyName("e")]
+        public string E { get; set; } = "";
+
+        /// <summary>
+        /// 数据包，不同事件可能具有不同的格式
+        /// </summary>
+        [JsonPropertyName("d")]
+        public object? D { get; set; } = null;
+
+        /// <summary>
+        /// 签名（握手成功前为空字符串）
+        /// </summary>
+        [JsonPropertyName("s")]
+        public string S { get; set; } = "";
+    }
+}

--- a/Model/Queue/GamingQueue.cs
+++ b/Model/Queue/GamingQueue.cs
@@ -121,9 +121,22 @@ namespace FunGame.Core.Model.Queue
         public ActionRecord? CurrentAction => _currentAction;
 
         /// <summary>
-        /// 回合记录外发通道（可为 null；设置后操作完成/回合决策完成时即时外发）
+        /// 本队列的 Guid（用于即时外发数据包的 g 字段）
         /// </summary>
-        public IRoundRecordSink? RoundRecordSink { get; set; } = null;
+        public Guid Guid { get; } = Guid.NewGuid();
+
+        /// <summary>
+        /// 回合记录外发通道（可为 null；设置后操作完成/回合结束/检查点回合时即时外发，并立即发起签名验证握手）
+        /// </summary>
+        public IRoundRecordSink? RoundRecordSink
+        {
+            get => _roundRecordSink;
+            set
+            {
+                _roundRecordSink = value;
+                value?.Attach(Guid);
+            }
+        }
 
         /// <summary>
         /// 状态检查点生成间隔（回合数）；大于 0 时每 N 回合在回合记录上附带一次全角色状态快照，0 或负数表示不生成
@@ -326,6 +339,11 @@ namespace FunGame.Core.Model.Queue
         /// 当前正在执行的操作记录
         /// </summary>
         protected ActionRecord? _currentAction = null;
+
+        /// <summary>
+        /// 回合记录外发通道
+        /// </summary>
+        private IRoundRecordSink? _roundRecordSink = null;
 
         #endregion
 
@@ -2063,10 +2081,13 @@ namespace FunGame.Core.Model.Queue
                     endTurn = true;
                 }
 
-                // 操作结算完成，即时外发单次操作记录
+                // 操作结算完成，即时外发单次操作记录与当前回合数据
                 if (_currentAction != null)
                 {
                     RoundRecordSink?.SendAction(_currentAction.Snapshot());
+                    RoundRecordSink?.SendRound(LastRound.Snapshot());
+                    RoundRecordSink?.SendQueueData(_hardnessTimes.ToDictionary(kv => kv.Key.Guid, kv => kv.Value));
+                    RoundRecordSink?.SendEliminatedCharacters(_eliminated.Select(c => c.Guid.ToString()));
                     // 操作已成功结算，清空当前操作，避免与下一轮行动混淆
                     _currentAction = null;
                 }
@@ -2141,8 +2162,10 @@ namespace FunGame.Core.Model.Queue
 
                 _isInRound = false;
                 _currentAction = null;
-                // 游戏结束时也外发最终回合记录，含死亡结算数据
-                RoundRecordSink?.SendRound(LastRound.Snapshot());
+                // 游戏结束时也外发最终回合数据（检查点回合记录/统计数据/全角色/团队），含死亡结算数据
+                SendRoundEndData();
+                // 游戏结束，通知外发通道停止签名验证重试等
+                RoundRecordSink?.End();
                 return _isGameEnd;
             }
 
@@ -2158,8 +2181,8 @@ namespace FunGame.Core.Model.Queue
             AddCharacter(character, newHardnessTime, isCheckProtected);
             OnQueueUpdatedEvent(_queue, character, dp, newHardnessTime, QueueUpdatedReason.Action, "设置角色行动后的硬直时间。");
 
-            // 回合结算完成（含死亡/连杀/复活/硬直），即时外发回合记录
-            RoundRecordSink?.SendRound(LastRound.Snapshot());
+            // 回合结算完成（含死亡/连杀/复活/硬直），即时外发回合结束数据（检查点回合记录/统计数据/全角色/团队）
+            SendRoundEndData();
 
             effects = [.. character.Effects.OrderByDescending(e => e.Priority)];
             foreach (Effect effect in effects)
@@ -2206,6 +2229,31 @@ namespace FunGame.Core.Model.Queue
             WillPreCastSuperSkill();
 
             return _isGameEnd;
+        }
+
+        /// <summary>
+        /// 回合结算完成后即时外发回合结束数据（检查点回合记录 + 统计数据 + 全角色 + 团队 + 淘汰团队名单）
+        /// </summary>
+        private void SendRoundEndData()
+        {
+            // 检查点回合才外发内容更多的回合记录（事件 "2"）
+            if (LastRound.Checkpoint != null)
+            {
+                RoundRecordSink?.SendCheckpointRound(LastRound.Snapshot());
+            }
+            RoundRecordSink?.SendCharacterStatistics(_stats.ToDictionary(kv => kv.Key.Guid, kv => kv.Value));
+            RoundRecordSink?.SendCharacters([.. AllCharacters]);
+
+            // 可供扩展
+            AfterSendRoundEndData();
+        }
+
+        /// <summary>
+        /// 在 <see cref="SendRoundEndData"/> 之后触发，允许子类在回合结束后进行额外的即时外发操作
+        /// </summary>
+        protected virtual void AfterSendRoundEndData()
+        {
+
         }
 
         /// <summary>

--- a/Model/Queue/MixGamingQueue.cs
+++ b/Model/Queue/MixGamingQueue.cs
@@ -147,6 +147,8 @@ namespace FunGame.Core.Model.Queue
                 top++;
             }
             WriteLine("");
+            // 游戏结束，通知外发通道停止签名验证重试等
+            RoundRecordSink?.End();
         }
 
         /// <summary>

--- a/Model/Queue/TeamGamingQueue.cs
+++ b/Model/Queue/TeamGamingQueue.cs
@@ -134,6 +134,15 @@ namespace FunGame.Core.Model.Queue
         }
 
         /// <summary>
+        /// 回合结束后外发团队数据
+        /// </summary>
+        protected override void AfterSendRoundEndData()
+        {
+            RoundRecordSink?.SendTeams([.. _teams.Values]);
+            RoundRecordSink?.SendEliminatedTeams([.. _eliminatedTeams.Select(t => t.Name)]);
+        }
+
+        /// <summary>
         /// 死亡结算时
         /// </summary>
         /// <param name="death"></param>
@@ -341,6 +350,8 @@ namespace FunGame.Core.Model.Queue
             }
             WriteLine("");
             _isGameEnd = true;
+            // 游戏结束，通知外发通道停止签名验证重试等
+            RoundRecordSink?.End();
         }
 
         /// <summary>


### PR DESCRIPTION
# GamingQueue 即时数据外发功能需求设计说明

## 1. 功能概述
本功能允许游戏逻辑（GamingQueue）将游戏过程中产生的回合数据、角色操作、统计信息等，以 HTTP POST 方式主动、实时地外发到外部配置的专用服务器。开发者可通过实现标准接口或使用内置默认类，灵活指定接收地址、关注的事件类型以及安全签名。

## 2. 术语定义
| 术语 | 说明 |
|------|------|
| GamingQueue | 管理游戏回合与角色操作的核心队列系统 |
| RoundRecordSink | 数据外发槽，负责将内部事件序列化并 POST 到远程服务器 |
| IRoundRecordSink | 数据外发接口，允许自定义协议实现 |
| DefaultRoundRecordSink | 系统提供的内置实现，位于 Api 命名空间 |
| RoundRecordPayload | 所有 POST 请求的统一 JSON 荷载模型 |
| secret | 预共享密钥，用于签名握手，确保通信端可信 |
| 事件 e | 荷载中的事件类型编码，决定数据包 d 的结构和含义 |
| 握手 | 在 secret 不为空时，通过事件 “13” 完成双向验证的过程 |

## 3. 前置条件
- 外部服务器必须提供一个可访问的 **POST** 端点。
- 该端点的请求体（body）能够接收并解析与 `RoundRecordPayload` 相同格式的 JSON。
- 服务器需在 5 秒内返回 HTTP 200 状态码，否则将影响游戏性能。

## 4. 功能配置

### 4.1 基本配置方式
- **创建 DefaultRoundRecordSink 实例**  
  构造函数参数：
  - `url: string` – 目标 POST 地址
  - `intents: string[]` – 需要订阅的事件编码列表（见第6节）

- **可选属性（实例化后赋值）**
  - `accessToken: string` – 若服务器要求 Bearer Token 鉴权，可设置此值，默认为空
  - `secret: string` – 预共享密钥，用于签名握手，默认为空（不使用签名）

- **激活外发**  
  将实现 `IRoundRecordSink` 的对象赋值给静态属性：
  ```csharp
  GamingQueue.RoundRecordSink = sinkInstance;
  ```

### 4.2 自定义协议
开发者可实现 `IRoundRecordSink` 接口，自主处理数据序列化、传输协议甚至加密，完全替代默认行为。

## 5. 数据荷载模型 (RoundRecordPayload)
所有 POST 请求体均为 JSON 对象，包含以下字段：

| 字段 | 类型 | 说明 |
|------|------|------|
| `g` | string | 当前 GamingQueue 实例的 Guid |
| `t` | number | 发送时的 Unix 时间戳 |
| `e` | string | 事件类型编码，决定 `d` 的结构 |
| `d` | object/string | 事件携带的数据，类型取决于 `e` |
| `s` | string | 签名哈希（握手成功前为空字符串） |

## 6. 事件定义
| e 值 | 事件名称 | d 数据类型 | 发送时机 |
|------|----------|------------|----------|
| "0" | 角色操作 | ActionRecord | 每次角色操作结束后 |
| "1" | 当前回合数据 | RoundRecord | 每次角色操作结束后 |
| "2" | 检查点回合数据 | RoundRecord | 回合结束且为检查点时 |
| "3" | 全角色统计 | CharacterStatistics | 回合结束时 |
| "4" | 全角色完整数据 | Character[] | 回合结束时 |
| "5" | 团队完整数据 | Team[] | 回合结束时 |
| "6" | 行动顺序表 | Dictionary<string, double> | 每次角色操作结束后 |
| "7" | 已淘汰角色名单 | string[] (角色Guid) | 每次角色操作结束后 |
| "8" | 已淘汰团队名单 | string[] (团队Name) | 每次角色操作结束后 |
| "13" | 签名验证 | string | 配置生效后立即发送 |

> 注：开发者通过在 `intents` 数组中声明事件编码来选择需要接收哪些事件。

## 7. 安全与签名握手流程

### 7.1 触发条件
当 `DefaultRoundRecordSink.secret` 不为空，且 `GamingQueue.RoundRecordSink` 被赋值后，系统**立即**启动握手。

### 7.2 步骤详解
1. **GamingQueue 发送事件 “13”**
   - 荷载中：
     - `e = "13"`
     - `d = SHA256(secret)` 的十六进制字符串
     - `s = ""`
     - `t = 当前时间戳`

2. **服务器处理与应答**
   - 接收 `d` 和 `t`
   - 拼接密钥材料：`keyMaterial = d的前10个字符 + d的后10个字符 + t`（字符串直接拼接）
   - 以 `keyMaterial` 为密钥，使用 **HMAC-SHA512** 算法对原始 `secret` 计算哈希值
   - 返回 HTTP 200，响应体**直接放置**该哈希的十六进制字符串

3. **GamingQueue 验证**
   - 对比服务器返回的哈希与自身计算值
   - **成功**：握手完成，后续所有 POST 请求的 `s` 字段均填写该哈希值
   - **失败**：暂停发送所有其他事件，每隔 **1 分钟** 重试发送事件 “13”，直至成功或游戏结束

### 7.3 服务器存储要求
服务器端必须安全存储与游戏端相同的原始 `secret` 字符串，以便独立计算 HMAC。

## 8. 性能与可靠性约束
- **响应时限**：每个 POST 请求必须在 **5 秒**内返回 `200 OK`，否则可能阻塞后续发送，进而影响游戏性能。
- **消息可靠性**：若服务器暂时不可达或超时，**错过的消息不会补发**。服务器需保证高可用，或采用先接收并立即异步化处理的架构（只要在 5 秒内返回响应）。
- **握手重试**：仅握手事件在失败后会自动重试，业务事件在握手成功前**完全抑制**。

## 9. 实现建议
- 接收端点应实现快速响应（如先将数据放入内存队列并返回 200，再异步入库）。
- 服务器需根据 `e` 字段动态反序列化 `d`，不同事件对应不同模型。
- 签名握手完成后，可对后续请求进行 `s` 字段校验，过滤非法请求。
- 如用自定义 `IRoundRecordSink`，需自行处理重试、连接超时及签名等逻辑，避免阻塞主游戏线程。