### PR TITLE
战斗系统实体 Equal 比较应用Guid

### DIFF
--- a/Entity/Character/Character.cs
+++ b/Entity/Character/Character.cs
@@ -1340,13 +1340,13 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
-        /// 比较一个角色 检查Id.Name
+        /// 比较一个角色 检查Guid
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
         public override bool Equals(IBaseEntity? other)
         {
-            return other is Character c && c.GetIdName() == GetIdName();
+            return other is Character c && c.Guid == Guid;
         }
 
         /// <summary>
@@ -1358,12 +1358,12 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
-        /// 获取角色的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Id.Name）
+        /// 获取角色的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Guid）
         /// </summary>
         /// <returns></returns>
         public override int GetHashCode()
         {
-            return GetIdName().GetHashCode();
+            return Guid.GetHashCode();
         }
 
         /// <summary>

--- a/Entity/Item/Item.cs
+++ b/Entity/Item/Item.cs
@@ -639,13 +639,13 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
-        /// 判断两个物品是否相同 检查Id.Name
+        /// 判断两个物品是否相同 检查Guid
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
         public override bool Equals(IBaseEntity? other)
         {
-            return other is Item i && i.GetIdName() == GetIdName();
+            return other is Item i && i.Guid == Guid;
         }
 
         /// <summary>
@@ -657,12 +657,12 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
-        /// 获取物品的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Id.Name）
+        /// 获取物品的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Guid）
         /// </summary>
         /// <returns></returns>
         public override int GetHashCode()
         {
-            return GetIdName().GetHashCode();
+            return Guid.GetHashCode();
         }
 
         /// <summary>

--- a/Entity/Skill/NormalAttack.cs
+++ b/Entity/Skill/NormalAttack.cs
@@ -10,6 +10,11 @@ namespace FunGame.Core.Entity
     public class NormalAttack(Character character, bool isMagic = false, MagicType magicType = MagicType.None) : BaseEntity, ISkill
     {
         /// <summary>
+        /// 普通攻击实例的唯一标识
+        /// </summary>
+        public override Guid Guid { get; set; } = Guid.NewGuid();
+
+        /// <summary>
         /// 普通攻击名称
         /// </summary>
         public override string Name => "普通攻击";
@@ -450,13 +455,30 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
-        /// 比较两个普攻对象
+        /// 比较两个普攻对象 检查Guid（实例身份）
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
         public override bool Equals(IBaseEntity? other)
         {
-            return other is NormalAttack c && c.Name == Name;
+            return other is NormalAttack c && c.Guid == Guid;
+        }
+
+        /// <summary>
+        /// 与 <see cref="Equals(IBaseEntity?)"/> 保持一致（字典默认比较器使用 <see cref="object.Equals(object?)"/>）
+        /// </summary>
+        public override bool Equals(object? obj)
+        {
+            return obj is IBaseEntity other && Equals(other);
+        }
+
+        /// <summary>
+        /// 获取普攻的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Guid）
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return Guid.GetHashCode();
         }
 
         /// <summary>

--- a/Entity/Skill/Skill.cs
+++ b/Entity/Skill/Skill.cs
@@ -1000,13 +1000,13 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
-        /// 判断两个技能是否相同 检查Id.Name
+        /// 判断两个技能是否相同 检查Guid
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
         public override bool Equals(IBaseEntity? other)
         {
-            return other is Skill s && s.GetIdName() == GetIdName();
+            return other is Skill s && s.Guid == Guid;
         }
 
         /// <summary>
@@ -1018,12 +1018,12 @@ namespace FunGame.Core.Entity
         }
 
         /// <summary>
-        /// 获取技能的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Id.Name）
+        /// 获取技能的哈希值（与 <see cref="Equals(IBaseEntity?)"/> 保持一致，基于 Guid）
         /// </summary>
         /// <returns></returns>
         public override int GetHashCode()
         {
-            return GetIdName().GetHashCode();
+            return Guid.GetHashCode();
         }
 
         /// <summary>

--- a/Library/Common/JsonConverter/EntityRefHelper.cs
+++ b/Library/Common/JsonConverter/EntityRefHelper.cs
@@ -126,13 +126,14 @@ namespace FunGame.Core.Library.Common.JsonConverter
     }
 
     /// <summary>
-    /// 技能引用（轻量快照）的读写辅助：只保留 Id 与名称，供展示与消耗匹配
+    /// 技能引用（轻量快照）的读写辅助：保留 Guid、Id、名称与类型，供展示与消耗匹配
     /// </summary>
     internal static class SkillRefHelper
     {
         public static void Write(Utf8JsonWriter writer, Skill? skill)
         {
             writer.WriteStartObject();
+            writer.WriteString(nameof(Skill.Guid), skill?.Guid ?? Guid.Empty);
             writer.WriteNumber(nameof(Skill.Id), skill?.Id ?? 0);
             writer.WriteString(nameof(Skill.Name), skill?.Name ?? "");
             writer.WriteNumber(nameof(Skill.SkillType), (int)(skill?.SkillType ?? SkillType.Magic));
@@ -147,21 +148,23 @@ namespace FunGame.Core.Library.Common.JsonConverter
 
         internal static Skill? ReadElement(JsonElement root)
         {
+            Guid guid = root.TryGetProperty(nameof(Skill.Guid), out JsonElement guidElement) && guidElement.ValueKind == JsonValueKind.String ? guidElement.GetGuid() : Guid.Empty;
             long id = root.TryGetProperty(nameof(Skill.Id), out JsonElement idElement) && idElement.ValueKind == JsonValueKind.Number ? idElement.GetInt64() : 0;
             string name = root.TryGetProperty(nameof(Skill.Name), out JsonElement nameElement) && nameElement.ValueKind == JsonValueKind.String ? nameElement.GetString() ?? "" : "";
             SkillType skillType = root.TryGetProperty(nameof(Skill.SkillType), out JsonElement stElement) && stElement.ValueKind == JsonValueKind.Number ? (SkillType)stElement.GetInt32() : SkillType.Magic;
-            return id == 0 && name == "" ? null : new OpenSkill(id, name, []) { SkillType = skillType };
+            return id == 0 && name == "" ? null : new OpenSkill(id, name, []) { SkillType = skillType, Guid = guid };
         }
     }
 
     /// <summary>
-    /// 物品引用（轻量快照）的读写辅助：只保留 Id 与名称，供展示与消耗匹配
+    /// 物品引用（轻量快照）的读写辅助：保留 Guid、Id 与名称，供展示与消耗匹配
     /// </summary>
     internal static class ItemRefHelper
     {
         public static void Write(Utf8JsonWriter writer, Item? item)
         {
             writer.WriteStartObject();
+            writer.WriteString(nameof(Item.Guid), item?.Guid ?? Guid.Empty);
             writer.WriteNumber(nameof(Item.Id), item?.Id ?? 0);
             writer.WriteString(nameof(Item.Name), item?.Name ?? "");
             writer.WriteEndObject();
@@ -175,9 +178,10 @@ namespace FunGame.Core.Library.Common.JsonConverter
 
         internal static Item? ReadElement(JsonElement root)
         {
+            Guid guid = root.TryGetProperty(nameof(Item.Guid), out JsonElement guidElement) && guidElement.ValueKind == JsonValueKind.String ? guidElement.GetGuid() : Guid.Empty;
             long id = root.TryGetProperty(nameof(Item.Id), out JsonElement idElement) && idElement.ValueKind == JsonValueKind.Number ? idElement.GetInt64() : 0;
             string name = root.TryGetProperty(nameof(Item.Name), out JsonElement nameElement) && nameElement.ValueKind == JsonValueKind.String ? nameElement.GetString() ?? "" : "";
-            return id == 0 && name == "" ? null : new OpenItem(id, name, []);
+            return id == 0 && name == "" ? null : new OpenItem(id, name, []) { Guid = guid };
         }
     }
 }


### PR DESCRIPTION
先前 #162 使用 GetIdName 对战斗系统不是很友好，因为存在大量的 Dictionary/HashSet 需要对不同引用的角色/物品/技能做区分。